### PR TITLE
update: wording reset password on success

### DIFF
--- a/components/ResetPassword/Success/index.vue
+++ b/components/ResetPassword/Success/index.vue
@@ -14,7 +14,7 @@
           Ubah Password Berhasil
         </h1>
         <p class="text-gray-800 font-lato text-sm pt-4 dark:text-dark-text-medium">
-          Perubahan password berhasil dilakukan.
+          Perubahan password akun dengan email <strong>{{ email }}</strong> berhasil dilakukan. Silakan masuk ke akun Anda di aplikasi Sapawarga.
         </p>
       </div>
     </div>
@@ -30,6 +30,15 @@ export default {
   components: {
     IconKey,
     IconCheck
+  },
+  props: {
+    /**
+     * make modal visible or not
+     */
+    email: {
+      type: String,
+      default: ''
+    }
   }
 }
 </script>

--- a/components/ResetPassword/Success/index.vue
+++ b/components/ResetPassword/Success/index.vue
@@ -32,9 +32,6 @@ export default {
     IconCheck
   },
   props: {
-    /**
-     * make modal visible or not
-     */
     email: {
       type: String,
       default: ''

--- a/pages/change-password-forgot/index.vue
+++ b/pages/change-password-forgot/index.vue
@@ -22,6 +22,7 @@
       />
       <ResetPasswordSuccess
         v-else-if="display === 'success'"
+        :email="email"
       />
     </div>
   </div>
@@ -36,7 +37,8 @@ export default {
   components: { IconLogo, IconArrowLeft },
   data () {
     return {
-      display: 'form'
+      display: 'form',
+      email: ''
     }
   },
   methods: {
@@ -53,7 +55,7 @@ export default {
         const timestamp = dataDecoded.split(':').slice(2).join(':')
 
         try {
-          await this.$axios.post('/user/auth/change-password-forgot', {
+          const response = await this.$axios.post('/user/auth/change-password-forgot', {
             token: tokenEncoded,
             userId,
             password
@@ -62,6 +64,8 @@ export default {
               'X-Timestamp': timestamp
             }
           })
+          const { data } = response.data
+          this.email = data?.email
           this.display = 'success'
         } catch (error) {
           this.display = 'form'


### PR DESCRIPTION
## Overview
Add data email in change password (forgot password) on success

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/65396086/197683093-238a42a3-bc38-4583-80e7-bf371117329f.png">

# Evidence
title: add data email in change password (forgot password) on success
project: Jabar Super Apps
participants: @yoslie @doohanas @agunghide @Ibwedagama @maulanayuseph @marsellavaleria19 