### PR TITLE
fix: form imah aing (ui enhancement)

### DIFF
--- a/components/Base/Dropzone/index.vue
+++ b/components/Base/Dropzone/index.vue
@@ -8,7 +8,7 @@
     @drop.prevent="onDropFile"
   >
     <Icon class="mb-3" src="/icon/add-image.svg" size="36px" />
-    <label for="file" class="cursor-pointer text-center">
+    <label :for="uniqueInputId" class="cursor-pointer text-center">
       <span
         class="font-lato font-medium text-sm leading-6 text-blue-gray-300 mb-3"
       >
@@ -24,7 +24,7 @@
       </span>
     </label>
     <input
-      id="file"
+      :id="uniqueInputId"
       type="file"
       hidden
       :accept="accept"
@@ -83,6 +83,11 @@ export default {
     multiple: {
       type: Boolean,
       default: false,
+    },
+  },
+  computed: {
+    uniqueInputId() {
+      return `dropzone-input-${this._uid}`
     },
   },
   mounted() {

--- a/components/Base/InputText/index.vue
+++ b/components/Base/InputText/index.vue
@@ -8,7 +8,7 @@
         }"
         :for="label"
       >
-        {{ label }}
+        {{ label }}<span v-if="required" class="text-red-500 pl-1" aria-hidden="true">*</span>
       </label>
       <div
         v-if="isShowPasswordLevel && levelPassword"
@@ -59,6 +59,7 @@
         :autofocus="autofocus"
         autocomplete="on"
         :disabled="disabled"
+        :aria-required="required"
         @focus="isFocused = true"
         @blur="isFocused = false"
         @input="onInput"
@@ -148,6 +149,13 @@ export default {
     placeholder: {
       type: String,
       default: ''
+    },
+    /**
+     * Show red asterisk after label (required field indicator)
+     */
+    required: {
+      type: Boolean,
+      default: false
     },
     /**
      * Error state

--- a/components/ImahAing/Form/StepTwo.vue
+++ b/components/ImahAing/Form/StepTwo.vue
@@ -14,8 +14,17 @@
 
     <!-- No HP Pengusul -->
     <ValidationProvider v-slot="{ errors }" class="flex flex-col gap-2 mb-5" rules="required" name="No HP Pengusul" vid="phone">
-      <label>No HP Pengusul <span class="text-red-500">*</span></label>
-      <JdsInputText :value="setPhone" inputmode="numeric" type="number" :error-message="errors[0]" @input="setPhone = $event" />
+      <BaseInputText
+        v-model="setPhone"
+        class="step-two-input-jds"
+        type="number"
+        label="No HP Pengusul"
+        required
+        :placeholder="zwsPlaceholder"
+        autocomplete="off"
+        :error="!!errors[0]"
+        :error-message="errors[0]"
+      />
     </ValidationProvider>
 
     <!-- Email Pribadi — OPSIONAL, EDITABLE -->
@@ -26,14 +35,32 @@
 
     <!-- NIK — WAJIB -->
     <ValidationProvider v-slot="{ errors }" class="flex flex-col gap-2 mb-5" rules="required|numeric|length:16" name="NIK" vid="nik">
-      <label>NIK <span class="text-red-500">*</span></label>
-      <JdsInputText :value="setNik" :error-message="errors[0]" @input="setNik = $event" />
+      <BaseInputText
+        v-model="setNik"
+        class="step-two-input-jds"
+        type="number"
+        label="NIK"
+        required
+        :placeholder="zwsPlaceholder"
+        autocomplete="off"
+        :error="!!errors[0]"
+        :error-message="errors[0]"
+      />
     </ValidationProvider>
 
     <!-- Nomor KK — WAJIB -->
     <ValidationProvider v-slot="{ errors }" class="flex flex-col gap-2 mb-5" rules="required|numeric|length:16" name="Nomor KK" vid="nomorKk">
-      <label>Nomor KK <span class="text-red-500">*</span></label>
-      <JdsInputText :value="setNomorKk" :error-message="errors[0]" @input="setNomorKk = $event" />
+      <BaseInputText
+        v-model="setNomorKk"
+        class="step-two-input-jds"
+        type="number"
+        label="Nomor KK"
+        required
+        :placeholder="zwsPlaceholder"
+        autocomplete="off"
+        :error="!!errors[0]"
+        :error-message="errors[0]"
+      />
     </ValidationProvider>
     </section>
   </ValidationObserver>
@@ -41,6 +68,12 @@
 
 <script>
 export default {
+  data() {
+    return {
+      /** Zero-width space: enables :placeholder-shown for JDS-like empty background (see .spec/template/InputText.scss) */
+      zwsPlaceholder: '\u200B',
+    }
+  },
   computed: {
     name() {
       return this.$store.state.imahAingForm.dataPengusul.name
@@ -99,3 +132,66 @@ export default {
   },
 }
 </script>
+
+<style scoped>
+/*
+ * Align BaseInputText with JdsInputText / InputText.scss (.spec/template) and
+ * .citizen__form .jds-input-text rules on pages/imah-aing/form/index.vue
+ */
+.step-two-input-jds {
+  width: 100%;
+}
+
+::v-deep .step-two-input-jds.flex.flex-col {
+  gap: 0.5rem;
+}
+
+/* Input shell — mirrors .jds-input-text__input-wrapper */
+::v-deep .step-two-input-jds > div:nth-child(2) {
+  transition: border-color 0.3s ease-out;
+  background-color: #fff;
+}
+
+::v-deep .step-two-input-jds > div:nth-child(2):has(input:placeholder-shown) {
+  background-color: #fafafa;
+}
+
+/* Default border: gray-500 (JDS) instead of gray-400; keep focus/error utilities */
+::v-deep .step-two-input-jds > div:nth-child(2).border-gray-400:not(.border-green-700):not(.border-red-700) {
+  border-color: #737373;
+}
+
+::v-deep .step-two-input-jds > div:nth-child(2):hover:not(:focus-within):not(.border-red-700) {
+  border-color: #15803d;
+}
+
+/* Focus ring: green border (from Base) + inset yellow (JDS --focused) */
+::v-deep .step-two-input-jds > div:nth-child(2):focus-within:not(.border-red-700) {
+  box-shadow: inset 0 0 0 1px #eab308;
+}
+
+::v-deep .step-two-input-jds > div:nth-child(2).border-red-700 {
+  box-shadow: none;
+}
+
+/* Match .citizen__form .jds-input-text input */
+::v-deep .step-two-input-jds input {
+  background-color: transparent !important;
+  width: 100%;
+  height: 100%;
+  font-size: 14px;
+  color: #616161;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+::v-deep .step-two-input-jds input::-webkit-outer-spin-button,
+::v-deep .step-two-input-jds input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+::v-deep .step-two-input-jds input[type='number'] {
+  -moz-appearance: textfield;
+}
+</style>

--- a/components/ImahAing/Form/StepTwo.vue
+++ b/components/ImahAing/Form/StepTwo.vue
@@ -6,17 +6,17 @@
       <img :src="avatarUrl || '/images/ilustrasi-ktp.webp'" alt="avatar" class="w-24 h-24 rounded-full object-cover" />
     </div>
 
-    <!-- Nama Pengusul — READ ONLY -->
-    <div class="flex flex-col gap-2 mb-5">
+    <!-- Nama Pengusul -->
+    <ValidationProvider v-slot="{ errors }" class="flex flex-col gap-2 mb-5" rules="required" name="Nama Pengusul" vid="name">
       <label>Nama Pengusul <span class="text-red-500">*</span></label>
-      <JdsInputText :value="name" />
-    </div>
+      <JdsInputText :value="setName" :error-message="errors[0]" @input="setName = $event" />
+    </ValidationProvider>
 
-    <!-- No HP Pengusul — READ ONLY -->
-    <div class="flex flex-col gap-2 mb-5">
+    <!-- No HP Pengusul -->
+    <ValidationProvider v-slot="{ errors }" class="flex flex-col gap-2 mb-5" rules="required" name="No HP Pengusul" vid="phone">
       <label>No HP Pengusul <span class="text-red-500">*</span></label>
-      <JdsInputText :value="phone" />
-    </div>
+      <JdsInputText :value="setPhone" inputmode="numeric" type="number" :error-message="errors[0]" @input="setPhone = $event" />
+    </ValidationProvider>
 
     <!-- Email Pribadi — OPSIONAL, EDITABLE -->
     <ValidationProvider v-slot="{ errors }" class="flex flex-col gap-2 mb-5" rules="email" name="Email Pribadi" vid="email">
@@ -73,6 +73,22 @@ export default {
       },
       set(val) {
         this.$store.commit('imahAingForm/SET_DATA_PENGUSUL_FIELD', { field: 'nomorKk', value: val })
+      },
+    },
+    setName: {
+      get() {
+        return this.$store.state.imahAingForm.dataPengusul.name
+      },
+      set(val) {
+        this.$store.commit('imahAingForm/SET_DATA_PENGUSUL_FIELD', { field: 'name', value: val })
+      },
+    },
+    setPhone: {
+      get() {
+        return this.$store.state.imahAingForm.dataPengusul.phone
+      },
+      set(val) {
+        this.$store.commit('imahAingForm/SET_DATA_PENGUSUL_FIELD', { field: 'phone', value: val })
       },
     },
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -26,6 +26,7 @@ export default {
   plugins: [
     '~/plugins/vue-gtag.js',
     '~/plugins/aduan-api.js',
+    '~/plugins/imah-aing-mock.js',
     '~/plugins/aduan-get-token.js',
     { src: '~/plugins/dark-mode.js', mode: 'client' },
     { src: '~/plugins/vee-validate.js', mode: 'client' },
@@ -111,6 +112,7 @@ export default {
       keycloakClientSecret: process.env.KEYCLOAK_CLIENT_SECRET_PARTNER,
     },
     urlFile: process.env.URL_FILE,
+    useMockImahAing: process.env.USE_MOCK_IMAH_AING === 'true',
     unleash: {
       unleashURL: process.env.UNLEASH_URL,
       unleashToken: process.env.UNLEASH_TOKEN,

--- a/plugins/imah-aing-mock.js
+++ b/plugins/imah-aing-mock.js
@@ -1,0 +1,53 @@
+const MOCK_UPLOAD_PATH = 'mock/imah-aing/document.jpg'
+
+const MOCK_CITIES = [
+  { id: '3273', name: 'Kota Bandung' },
+  { id: '3204', name: 'Kabupaten Bandung' },
+  { id: '3201', name: 'Kabupaten Bogor' },
+]
+
+const MOCK_DISTRICTS = [
+  { id: '3273010', name: 'Sukasari' },
+  { id: '3273020', name: 'Coblong' },
+  { id: '3273030', name: 'Cicendo' },
+]
+
+const MOCK_VILLAGES = [
+  { id: '3273020001', name: 'Cipaganti' },
+  { id: '3273020002', name: 'Lebakgede' },
+  { id: '3273020003', name: 'Sekeloa' },
+]
+
+const wait = (duration = 500) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, duration)
+  })
+
+export default (_context, inject) => {
+  const imahAingMock = {
+    async uploadDocument() {
+      await wait(800)
+      return {
+        data: {
+          path: MOCK_UPLOAD_PATH,
+        },
+      }
+    },
+    getAreas({ depth }) {
+      if (Number(depth) === 2) return MOCK_CITIES
+      if (Number(depth) === 3) return MOCK_DISTRICTS
+      if (Number(depth) === 4) return MOCK_VILLAGES
+      return []
+    },
+    async submitForm() {
+      await wait(600)
+      return {
+        data: {
+          id: `mock-submission-${Date.now()}`,
+        },
+      }
+    },
+  }
+
+  inject('imahAingMock', imahAingMock)
+}

--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -247,6 +247,19 @@ export default {
       commit('SET_DOKUMEN_SLOT', { key, payload })
 
       try {
+        if (this.$config.useMockImahAing && this.$imahAingMock) {
+          commit('SET_DOKUMEN_SLOT', { key, payload: { ...payload, progress: 30 } })
+          const mockResponse = await this.$imahAingMock.uploadDocument()
+          const fileUrl = `${this.$config.urlFile}/${mockResponse.data.path}`
+
+          commit('SET_DOKUMEN_SLOT', {
+            key,
+            payload: { file, url: fileUrl, progress: 100, status: 'SUCCESS', errors: [] },
+          })
+
+          return fileUrl
+        }
+
         // simulate progress
         commit('SET_DOKUMEN_SLOT', { key, payload: { ...payload, progress: 20 } })
 
@@ -318,7 +331,10 @@ export default {
           RW: String(rw || ''),
         }
 
-        const response = await this.$axios.post('/v1/aduan/complaints', payload)
+        const response =
+          this.$config.useMockImahAing && this.$imahAingMock
+            ? await this.$imahAingMock.submitForm(payload)
+            : await this.$axios.post('/v1/aduan/complaints', payload)
         const submissionId = response.data?.data?.id || response.data?.id || ''
 
         commit('SET_STATUS_SUBMIT', 'SUCCESS')

--- a/store/location.js
+++ b/store/location.js
@@ -58,15 +58,22 @@ const actions = {
 
       if (endpoints[params.depth]) {
         const { url, mutation } = endpoints[params.depth]
-        const response = await this.$axios.get(url, { params })
+        let areas = []
 
-        commit(mutation, response.data.data)
+        if (this.$config.useMockImahAing && this.$imahAingMock) {
+          areas = this.$imahAingMock.getAreas(params)
+        } else {
+          const response = await this.$axios.get(url, { params })
+          areas = response.data.data
+        }
+
+        commit(mutation, areas)
 
         if (params.depth === 2 && localStorageKey) {
           localStorage.setItem(`${localStorageKey}Date`, new Date())
           localStorage.setItem(
             `${localStorageKey}Data`,
-            JSON.stringify(response.data.data)
+            JSON.stringify(areas)
           )
         }
       }


### PR DESCRIPTION
## FEAT
- PAGE 2 (StepTwo): validasi `required` untuk **Nama Pengusul** & **No HP Pengusul** via `ValidationProvider`; data tetap bisa diedit dan tersinkron ke store (sesuai latar belakang & acceptance criteria di plan).
- PAGE 2: input **No HP Pengusul** dibatasi sebagai input angka (`type="number"`) — mengingat keterbatasan `JdsInputText` untuk `type` number, implementasi memakai **`BaseInputText`** untuk field numerik (No HP, NIK, Nomor KK) dengan styling diselaraskan ke pola JDS/citizen form.
- PAGE 3: perbaikan bug upload ke field salah — **`BaseDropzone`** memakai `id` / `for` unik per instance (mis. berbasis `_uid`) agar label tidak selalu mengarah ke input dropzone pertama.
- Verifikasi/perbaikan perilaku **tombol retry** di alur upload (`UploadProgress`): prop `showRetryButton` dipakai dengan benar; perilaku di **TrackingComplaint** vs **Imah Aing** sesuai analisis di plan (retry aktif/non-aktif sesuai konteks).
- Mock integrasi untuk mengatasi **CORS** sementara: plugin **`imah-aing-mock`**, flag runtime **`useMockImahAing`** (`USE_MOCK_IMAH_AING`), penyesuaian di store (upload dokumen Imah Aing, wilayah di `location`) agar PAGE 3 & 4 bisa diuji tanpa backend.

## Related
- 

## Overview
PR ini mengimplementasikan paket enhancement Form **Imah Aing** sesuai dokumen plan: perbaikan validasi & input data pengusul di PAGE 2, pembatasan input numerik untuk No HP (dan field terkait), perbaikan bug **Dropzone** di PAGE 3, audit perilaku **retry** upload, serta **mock layer** untuk upload & wilayah (dan alur terkait) agar pengujian tidak terblokir CORS hingga backend siap.

## Changes
- **`components/ImahAing/Form/StepTwo.vue`**: PAGE 2 — `ValidationProvider` untuk nama/HP (dan field terkait sesuai implementasi); No HP / NIK / KK memakai `BaseInputText` + styling selaras JDS; prop `required` pada label tidak lagi memakai `*` manual di string label.
- **`components/Base/InputText/index.vue`**: prop **`required`** (asterisk merah `text-red-500`), **`aria-required`** pada input.
- **`components/Base/Dropzone/index.vue`**: id input & `for` label unik per instance.
- **`plugins/imah-aing-mock.js`** + **`nuxt.config.js`**: mock & env `USE_MOCK_IMAH_AING` / `useMockImahAing`.
- **`store/imah-aing/imahAingForm.js`**, **`store/location.js`**: cabang mock untuk upload dokumen & fetch wilayah.
- File terkait upload (mis. `UploadProgress`, StepThree TrackingComplaint/Imah Aing) sesuai commit di branch — smoke test mengacu ke tabel dampak & acceptance criteria di plan.

## Preview
- 

## Evidence
title: Form Imah Aing UI Enhancement
project: Sapawarga
participants: @ekadhirapratama 
screenshot: https://s.digitalservice.id/nQAFeZ