### PR TITLE
fix: removing unnecessary headers from imahAing store

### DIFF
--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -275,9 +275,7 @@ export default {
           data: base64Data,
         }
 
-        const response = await this.$axios.post('/file/upload', formData, {
-          headers: { Authorization: `Bearer ${state.authToken}` },
-        })
+        const response = await this.$axios.post('/file/upload', formData)
 
         const fileUrl = `${this.$config.urlFile}/${response.data.data.path}`
 


### PR DESCRIPTION
## FEAT
- Menghapus header `Authorization` pada upload dokumen form Imah Aing agar permintaan ke `/file/upload` tidak memicu masalah CORS (preflight/header non-simple).

## Related
- 

## Overview
Pull request ini menyesuaikan pemanggilan `POST /file/upload` di store `imahAingForm` dengan menghapus header `Authorization: Bearer ...`. Sebelumnya header tersebut memakai nilai dari query `token` yang sama dengan data konteks pengguna (bukan access token OAuth), sehingga tidak sesuai untuk autentikasi API dan berpotensi memicu kegagalan CORS. Alur submit pengaduan ke `/v1/aduan/complaints` untuk Imah Aing tetap tanpa header Authorization manual, sehingga upload kini konsisten dengan pola tersebut.

## Changes
- `store/imah-aing/imahAingForm.js`: pada action `uploadDocument`, `this.$axios.post('/file/upload', formData)` dipanggil tanpa opsi `headers` berisi `Authorization`.

## Preview
- 

## Evidence
title: Perbaikan CORS pada upload dokumen Imah Aing (hapus Authorization di `/file/upload`)
project: Sapawarga
participants: @ekadhirapratama 
screenshot: https://s.digitalservice.id/1gn5Hg