### PR TITLE
fix: copywriting & integration for module Imah Aing

### DIFF
--- a/components/ImahAing/Form/StepOne.vue
+++ b/components/ImahAing/Form/StepOne.vue
@@ -11,9 +11,6 @@
       <p>
         Formulir ini diperuntukkan bagi <strong>Wargi yang mengusulkan dirinya sendiri sebagai calon penerima bantuan</strong>
       </p>
-      <p>
-        Untuk <strong>proses rekomendasi</strong> hanya bisa dilakukan <strong>melalui Ketua RT/Ketua RW/Kades melalui akun Sapawarga RT / RW / Kades</strong>
-      </p>
     </div>
 
     <div class="mb-4">
@@ -23,48 +20,51 @@
       <ol class="list-decimal ml-5 space-y-1">
         <li>Kartu Tanda Penduduk (KTP);</li>
         <li>Kartu Keluarga (KK);</li>
-        <li>Surat Keterangan Miskin dari RT;</li>
+        <li>Surat Keterangan Miskin / Tidak Mampu dari RT;</li>
         <li>Surat Keterangan Kepemilikan Tanah Dari Kepala Desa/Lurah; dan</li>
-        <li>Foto Tanah.</li>
+        <li>Foto rumah.</li>
       </ol>
     </div>
 
     <div class="flex flex-col gap-4 mt-8">
-      <label v-if="isSapawargaSource" class="flex items-center gap-3 cursor-pointer">
+      <label class="flex items-center gap-3 cursor-pointer">
         <input
-          v-model="setSapawargaCombinedConsent"
+          v-model="privacyAccepted"
           type="checkbox"
           class="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
         />
         <span class="text-sm">
           Saya menyatakan telah membaca, mempelajari, dan menyetujui
           <a href="https://sapawarga.digitalservice.id/kebijakan-privasi-ketentuan-pengguna" class="underline hover:text-blue-600">Kebijakan Privasi</a>
-          serta memberikan rekomendasi calon penerima bantuan
         </span>
       </label>
 
-      <template v-else>
-        <label class="flex items-center gap-3 cursor-pointer">
-          <input
-            v-model="setHasReadPrivacyPolicy"
-            type="checkbox"
-            class="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-          />
-          <span class="text-sm">
-            Saya menyatakan telah membaca, mempelajari, dan menyetujui
-            <a href="https://sapawarga.digitalservice.id/kebijakan-privasi-ketentuan-pengguna" class="underline hover:text-blue-600">Kebijakan Privasi</a>
-          </span>
-        </label>
+      <label class="flex items-start gap-3 cursor-pointer">
+        <input
+          v-model="stmtSingleHouse"
+          type="checkbox"
+          class="w-5 h-5 mt-0.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 flex-shrink-0"
+        />
+        <span class="text-sm">{{ copySingleHouse }}</span>
+      </label>
 
-        <label class="flex items-center gap-3 cursor-pointer">
-          <input
-            v-model="setIsBeneficiaryCandidate"
-            type="checkbox"
-            class="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-          />
-          <span class="text-sm">Saya adalah calon penerima bantuan</span>
-        </label>
-      </template>
+      <label class="flex items-start gap-3 cursor-pointer">
+        <input
+          v-model="stmtNoSimilarProgram"
+          type="checkbox"
+          class="w-5 h-5 mt-0.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 flex-shrink-0"
+        />
+        <span class="text-sm">{{ copyNoSimilarProgram }}</span>
+      </label>
+
+      <label class="flex items-start gap-3 cursor-pointer">
+        <input
+          v-model="stmtRevocationIfUntrue"
+          type="checkbox"
+          class="w-5 h-5 mt-0.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 flex-shrink-0"
+        />
+        <span class="text-sm">{{ copyRevocationIfUntrue }}</span>
+      </label>
     </div>
   </section>
 </template>
@@ -75,18 +75,22 @@ export default {
     isSapawargaSource() {
       return this.$store.state.imahAingForm.sourceId === 'sapawarga'
     },
-    /** One checkbox sets both consent flags so existing isConsentValid still applies */
-    setSapawargaCombinedConsent: {
-      get() {
-        const c = this.$store.state.imahAingForm.consent
-        return c.hasReadPrivacyPolicy && c.isBeneficiaryCandidate
-      },
-      set(val) {
-        this.$store.commit('imahAingForm/SET_CONSENT_PRIVACY', val)
-        this.$store.commit('imahAingForm/SET_CONSENT_BENEFICIARY', val)
-      },
+    copySingleHouse() {
+      return this.isSapawargaSource
+        ? 'Saya menyatakan bahwa rumah yang diajukan merupakan rumah tunggal calon penerima bantuan'
+        : 'Saya menyatakan bahwa rumah yang diajukan merupakan rumah tunggal saya'
     },
-    setHasReadPrivacyPolicy: {
+    copyNoSimilarProgram() {
+      return this.isSapawargaSource
+        ? 'Saya menyatakan bahwa calon penerima bantuan belum pernah menerima bantuan dari program serupa'
+        : 'Saya menyatakan bahwa saya belum pernah menerima bantuan dari program serupa'
+    },
+    copyRevocationIfUntrue() {
+      return this.isSapawargaSource
+        ? 'Saya menyatakan bahwa calon penerima bantuan bersedia dibatalkan jika data dan pernyataan yang saya berikan tidak benar'
+        : 'Saya bersedia dibatalkan pengajuannya jika data dan pernyataan yang saya berikan tidak benar'
+    },
+    privacyAccepted: {
       get() {
         return this.$store.state.imahAingForm.consent.hasReadPrivacyPolicy
       },
@@ -94,12 +98,28 @@ export default {
         this.$store.commit('imahAingForm/SET_CONSENT_PRIVACY', val)
       },
     },
-    setIsBeneficiaryCandidate: {
+    stmtSingleHouse: {
       get() {
-        return this.$store.state.imahAingForm.consent.isBeneficiaryCandidate
+        return this.$store.state.imahAingForm.consent.stmtSingleHouse
       },
       set(val) {
-        this.$store.commit('imahAingForm/SET_CONSENT_BENEFICIARY', val)
+        this.$store.commit('imahAingForm/SET_CONSENT_STATEMENT', { field: 'stmtSingleHouse', value: val })
+      },
+    },
+    stmtNoSimilarProgram: {
+      get() {
+        return this.$store.state.imahAingForm.consent.stmtNoSimilarProgram
+      },
+      set(val) {
+        this.$store.commit('imahAingForm/SET_CONSENT_STATEMENT', { field: 'stmtNoSimilarProgram', value: val })
+      },
+    },
+    stmtRevocationIfUntrue: {
+      get() {
+        return this.$store.state.imahAingForm.consent.stmtRevocationIfUntrue
+      },
+      set(val) {
+        this.$store.commit('imahAingForm/SET_CONSENT_STATEMENT', { field: 'stmtRevocationIfUntrue', value: val })
       },
     },
   },

--- a/components/ImahAing/Form/StepThree.vue
+++ b/components/ImahAing/Form/StepThree.vue
@@ -11,7 +11,8 @@
     <ul class="space-y-4">
       <li v-for="item in docsConfig" :key="item.key" class="flex flex-col gap-2">
         <div class="flex items-start gap-2 text-sm">
-          <span class="text-red-500 mt-0.5 flex-shrink-0">*</span>
+          <span v-if="item.required" class="text-red-500 mt-0.5 flex-shrink-0">*</span>
+          <span v-else class="w-1.5 flex-shrink-0" />
           <span class="font-roboto text-black dark:text-dark-emphasis-high">{{ item.label }}</span>
         </div>
 
@@ -19,7 +20,7 @@
           v-slot="{ errors }"
           :ref="`documentUploader_${item.key}`"
           class="flex flex-col gap-y-2"
-          rules="required"
+          :rules="item.required ? 'required' : ''"
           :name="item.label"
         >
           <BaseDropzone
@@ -50,6 +51,72 @@
         </transition>
       </li>
     </ul>
+
+    <div class="border-t border-gray-200 dark:border-dark-emphasis-medium pt-6 space-y-5">
+      <h4 class="font-roboto font-medium text-black text-sm dark:text-dark-emphasis-high">
+        Kondisi rumah
+      </h4>
+
+      <div class="flex flex-col gap-2">
+        <label
+          for="penyebabKerusakan"
+          class="text-sm font-medium text-black font-roboto dark:text-dark-emphasis-high"
+        >
+          Penyebab kerusakan
+        </label>
+        <JdsSelect
+          id="penyebabKerusakan"
+          v-model="setPenyebabKerusakan"
+          filterable
+          filter-type="contain"
+          placeholder="Pilih penyebab kerusakan"
+          :options="penyebabOptions"
+        />
+      </div>
+
+      <div v-if="kondisiRumah.penyebabKerusakan === 'lainnya'" class="flex flex-col gap-2">
+        <label
+          for="penyebabLainnya"
+          class="text-sm font-medium text-black font-roboto dark:text-dark-emphasis-high"
+        >
+          Penyebab lainnya
+        </label>
+        <JdsInputText
+          id="penyebabLainnya"
+          :value="setPenyebabKerusakanLainnya"
+          class="w-full"
+          placeholder="Jelaskan penyebab lainnya"
+          @input="setPenyebabKerusakanLainnya = $event"
+        />
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <label
+          for="deskripsiKondisi"
+          class="text-sm font-medium text-black font-roboto dark:text-dark-emphasis-high"
+        >
+          Deskripsi kondisi rumah
+        </label>
+        <textarea
+          id="deskripsiKondisi"
+          v-model="setDeskripsiKondisi"
+          rows="4"
+          class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-800 dark:bg-dark-emphasis-low dark:border-dark-emphasis-medium dark:text-dark-emphasis-high"
+          placeholder="Jelaskan kondisi rumah"
+        />
+      </div>
+
+      <label class="flex items-start gap-3 cursor-pointer">
+        <input
+          v-model="setPernyataanKepemilikanTunggal"
+          type="checkbox"
+          class="w-5 h-5 mt-0.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 flex-shrink-0"
+        />
+        <span class="text-sm text-black dark:text-dark-emphasis-high">
+          Saya menyatakan kepemilikan tunggal atas rumah ini (pernyataan bermaterai mengikuti ketentuan operasional).
+        </span>
+      </label>
+    </div>
   </section>
 </template>
 
@@ -60,29 +127,87 @@ export default {
   data() {
     return {
       docsConfig: [
-        { key: 'ktp', label: 'Kartu Tanda Penduduk (KTP) Calon Penerima Bantuan' },
-        { key: 'kk', label: 'Kartu Keluarga (KK) Calon Penerima Bantuan' },
-        { key: 'suratMiskin', label: 'Surat Keterangan Miskin dari Ketua RT' },
-        { key: 'suratTanah', label: 'Surat Keterangan Kepemilikan Tanah dari Kepala Desa/Lurah' },
-        { key: 'fotoTanah', label: 'Foto Tanah' },
+        { key: 'ktp', label: 'Kartu Tanda Penduduk (KTP) Calon Penerima Bantuan', required: true },
+        { key: 'kk', label: 'Kartu Keluarga (KK) Calon Penerima Bantuan', required: true },
+        {
+          key: 'suratMiskin',
+          label: 'Surat Keterangan Miskin / Tidak Mampu dari Ketua RT',
+          required: true,
+        },
+        {
+          key: 'suratTanah',
+          label: 'Surat Keterangan Kepemilikan Tanah dari Kepala Desa/Lurah',
+          required: true,
+        },
+        { key: 'fotoRumahDepan', label: 'Foto rumah — tampak depan (wajib)', required: true },
+        { key: 'fotoRumahKiri', label: 'Foto rumah — tampak kiri', required: false },
+        { key: 'fotoRumahKanan', label: 'Foto rumah — tampak kanan', required: false },
+        { key: 'fotoRumahDalam', label: 'Foto rumah — tampak dalam', required: false },
+        { key: 'fotoRumahBelakang', label: 'Foto rumah — tampak belakang', required: false },
+      ],
+      penyebabOptions: [
+        { value: 'bencana', label: 'Bencana' },
+        { value: 'umur_sudah_tua', label: 'Umur sudah tua' },
+        { value: 'tidak_terawat', label: 'Tidak terawat' },
+        { value: 'struktur_bangunan_tidak_baik', label: 'Struktur bangunan tidak baik' },
+        { value: 'lainnya', label: 'Lainnya' },
       ],
       accept: '.jpg, .jpeg, .png, .pdf',
       maxSize: 2 * 1024 * 1024, // 2 MB
     }
   },
   computed: {
-    ...mapState('imahAingForm', ['dokumen']),
+    ...mapState('imahAingForm', ['dokumen', 'kondisiRumah']),
     slotFor() {
-      return (key) => this.dokumen ? this.dokumen[key] : null
-    },
-    showDropzone() {
-      return (key) => {
-        const slot = this.dokumen ? this.dokumen[key] : null
-        return !slot || slot.status === 'NONE'
-      }
+      return (key) => (this.dokumen ? this.dokumen[key] : null)
     },
     hasUploadError() {
       return (key) => !!(this.dokumen?.[key]?.errors && this.dokumen[key].errors.length > 0)
+    },
+    setPenyebabKerusakan: {
+      get() {
+        return this.kondisiRumah.penyebabKerusakan || ''
+      },
+      set(val) {
+        const v = val != null ? String(val) : ''
+        this.$store.commit('imahAingForm/SET_KONDISI_RUMAH_FIELD', { field: 'penyebabKerusakan', value: v })
+        if (v !== 'lainnya') {
+          this.$store.commit('imahAingForm/SET_KONDISI_RUMAH_FIELD', {
+            field: 'penyebabKerusakanLainnya',
+            value: '',
+          })
+        }
+      },
+    },
+    setPenyebabKerusakanLainnya: {
+      get() {
+        return this.kondisiRumah.penyebabKerusakanLainnya
+      },
+      set(val) {
+        this.$store.commit('imahAingForm/SET_KONDISI_RUMAH_FIELD', {
+          field: 'penyebabKerusakanLainnya',
+          value: val,
+        })
+      },
+    },
+    setDeskripsiKondisi: {
+      get() {
+        return this.kondisiRumah.deskripsiKondisi
+      },
+      set(val) {
+        this.$store.commit('imahAingForm/SET_KONDISI_RUMAH_FIELD', { field: 'deskripsiKondisi', value: val })
+      },
+    },
+    setPernyataanKepemilikanTunggal: {
+      get() {
+        return this.kondisiRumah.pernyataanKepemilikanTunggalBermaterai
+      },
+      set(val) {
+        this.$store.commit('imahAingForm/SET_KONDISI_RUMAH_FIELD', {
+          field: 'pernyataanKepemilikanTunggalBermaterai',
+          value: val,
+        })
+      },
     },
   },
   methods: {
@@ -93,8 +218,9 @@ export default {
 
       const refName = `documentUploader_${key}`
       const provider = this.$refs[refName]
-      if (provider && typeof provider.validate === 'function') {
-        const { valid } = await provider.validate(selectedFile)
+      const p = Array.isArray(provider) ? provider[0] : provider
+      if (p && typeof p.validate === 'function') {
+        const { valid } = await p.validate(selectedFile)
         if (!valid) return
       }
 
@@ -120,7 +246,8 @@ export default {
       const input = document.querySelector(`#imahAingDocumentDropzone_${key} input`)
       if (input) input.value = ''
       const provider = this.$refs[`documentUploader_${key}`]
-      if (provider && typeof provider.syncValue === 'function') provider.syncValue()
+      const p = Array.isArray(provider) ? provider[0] : provider
+      if (p && typeof p.syncValue === 'function') p.syncValue()
     },
     async handleRetry(key) {
       const slot = this.slotFor(key)
@@ -146,7 +273,7 @@ export default {
 }
 
 .slide-fade-leave-active {
-  transition: all 0.2s cubic-bezier(1, 0.5, 0.8, 1);
+  transition: all 0.3s cubic-bezier(1, 0.5, 0.8, 1);
 }
 
 .slide-fade-enter,

--- a/components/ImahAing/Form/StepTwo.vue
+++ b/components/ImahAing/Form/StepTwo.vue
@@ -6,19 +6,19 @@
       <img :src="avatarUrl || '/images/ilustrasi-ktp.webp'" alt="avatar" class="w-24 h-24 rounded-full object-cover" />
     </div>
 
-    <!-- Nama Pengusul -->
-    <ValidationProvider v-slot="{ errors }" class="flex flex-col gap-2 mb-5" rules="required" name="Nama Pengusul" vid="name">
-      <label>Nama Pengusul <span class="text-red-500">*</span></label>
+    <!-- Nama Calon Penerima Bantuan -->
+    <ValidationProvider v-slot="{ errors }" class="flex flex-col gap-2 mb-5" rules="required" name="Nama Calon Penerima Bantuan" vid="name">
+      <label>Nama Calon Penerima Bantuan <span class="text-red-500">*</span></label>
       <JdsInputText :value="setName" :error-message="errors[0]" @input="setName = $event" />
     </ValidationProvider>
 
-    <!-- No HP Pengusul -->
-    <ValidationProvider v-slot="{ errors }" class="flex flex-col gap-2 mb-5" rules="required" name="No HP Pengusul" vid="phone">
+    <!-- No HP Calon Penerima Bantuan -->
+    <ValidationProvider v-slot="{ errors }" class="flex flex-col gap-2 mb-5" rules="required" name="No HP Calon Penerima Bantuan" vid="phone">
       <BaseInputText
         v-model="setPhone"
         class="step-two-input-jds"
         type="number"
-        label="No HP Pengusul"
+        label="No HP Calon Penerima Bantuan"
         required
         :placeholder="zwsPlaceholder"
         autocomplete="off"

--- a/components/ImahAing/Form/Stepper.vue
+++ b/components/ImahAing/Form/Stepper.vue
@@ -34,7 +34,7 @@ export default {
     return {
       formTitle: [
         { id: 1, title: 'Perhatian' },
-        { id: 2, title: 'Data Pengusul' },
+        { id: 2, title: 'Calon Penerima Bantuan' },
         { id: 3, title: 'Dokumen Yang Diperlukan' },
         { id: 4, title: 'Lokasi' },
       ],

--- a/pages/imah-aing/form/index.vue
+++ b/pages/imah-aing/form/index.vue
@@ -179,7 +179,7 @@ export default {
       isLoading: true,
       formTitle: [
         { id: 1, title: 'Perhatian' },
-        { id: 2, title: 'Data Pengusul' },
+        { id: 2, title: 'Calon Penerima Bantuan' },
         { id: 3, title: 'Dokumen Yang Diperlukan' },
         { id: 4, title: 'Lokasi Tanah untuk Pembangunan/Perbaikan Rumah' },
       ],

--- a/pages/imah-aing/form/index.vue
+++ b/pages/imah-aing/form/index.vue
@@ -194,6 +194,7 @@ export default {
       'startStep',
       'isConsentValid',
       'isAllDocumentsUploaded',
+      'hasAuthToken',
     ]),
     nextButtonDisabled() {
       const step = Number(this.currentFormStep)
@@ -215,6 +216,15 @@ export default {
   },
   async mounted() {
     this.showLoadingSkeleton()
+    if (!this.hasAuthToken) {
+      try {
+        const token = await this.$getToken('client_credentials')
+        this.setAuthToken(token)
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to get token:', error)
+      }
+    }
     await this.initForm(this.$route.query)
     this.hydrateLokasiTanahFromGeolocation()
     this.$store.commit('imahAingForm/SET_CURRENT_FORM_STEP', this.startStep)
@@ -227,6 +237,7 @@ export default {
       goToPreviousStep: 'previousStep',
       submitForm: 'submitForm',
       resetForm: 'resetForm',
+      setAuthToken: 'setAuthToken',
     }),
     async nextStep() {
       const step = Number(this.currentFormStep)
@@ -269,6 +280,15 @@ export default {
     async backToFormPage() {
       this.resetForm()
       this.showLoadingSkeleton()
+      if (!this.hasAuthToken) {
+        try {
+          const token = await this.$getToken('client_credentials')
+          this.setAuthToken(token)
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to get token:', error)
+        }
+      }
       await this.initForm(this.$route.query)
       this.hydrateLokasiTanahFromGeolocation()
       this.$store.commit('imahAingForm/SET_STATUS_SUBMIT', 'NONE')

--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -13,7 +13,18 @@ const getDefaultState = () => ({
 
   consent: {
     hasReadPrivacyPolicy: false,
-    isBeneficiaryCandidate: false,
+    /** Tiga pernyataan — teks UI beda sapawarga vs warga di StepOne */
+    stmtSingleHouse: false,
+    stmtNoSimilarProgram: false,
+    stmtRevocationIfUntrue: false,
+  },
+
+  /** PAGE 3 — penyebab/deskripsi/ceklis; payload API menyusul (lihat submitForm) */
+  kondisiRumah: {
+    penyebabKerusakan: '',
+    penyebabKerusakanLainnya: '',
+    deskripsiKondisi: '',
+    pernyataanKepemilikanTunggalBermaterai: false,
   },
 
   dataPengusul: {
@@ -30,7 +41,11 @@ const getDefaultState = () => ({
     kk: null,
     suratMiskin: null,
     suratTanah: null,
-    fotoTanah: null,
+    fotoRumahDepan: null,
+    fotoRumahKiri: null,
+    fotoRumahKanan: null,
+    fotoRumahDalam: null,
+    fotoRumahBelakang: null,
   },
 
   lokasiTanah: {
@@ -144,14 +159,31 @@ export default {
     isFirstStep: (state, getters) => state.currentFormStep === getters.startStep,
     isLastStep: (state) => state.currentFormStep === 4,
     startStep: () => 1,
-    isConsentValid: (state) =>
-      state.consent.hasReadPrivacyPolicy && state.consent.isBeneficiaryCandidate,
+    isConsentValid: (state) => {
+      const c = state.consent
+      return (
+        c.hasReadPrivacyPolicy &&
+        c.stmtSingleHouse &&
+        c.stmtNoSimilarProgram &&
+        c.stmtRevocationIfUntrue
+      )
+    },
     isAllDocumentsUploaded: (state) => {
-      const keys = ['ktp', 'kk', 'suratMiskin', 'suratTanah', 'fotoTanah']
-      return keys.every((k) => state.dokumen[k] && state.dokumen[k].status === 'SUCCESS')
+      const requiredKeys = ['ktp', 'kk', 'suratMiskin', 'suratTanah', 'fotoRumahDepan']
+      return requiredKeys.every((k) => state.dokumen[k] && state.dokumen[k].status === 'SUCCESS')
     },
     documentSlotsOrdered: (state) => {
-      const keys = ['ktp', 'kk', 'suratMiskin', 'suratTanah', 'fotoTanah']
+      const keys = [
+        'ktp',
+        'kk',
+        'suratMiskin',
+        'suratTanah',
+        'fotoRumahDepan',
+        'fotoRumahKiri',
+        'fotoRumahKanan',
+        'fotoRumahDalam',
+        'fotoRumahBelakang',
+      ]
       return keys.map((k) => ({ key: k, slot: state.dokumen[k] }))
     },
   },
@@ -165,8 +197,15 @@ export default {
     SET_CONSENT_PRIVACY(state, val) {
       state.consent.hasReadPrivacyPolicy = val
     },
-    SET_CONSENT_BENEFICIARY(state, val) {
-      state.consent.isBeneficiaryCandidate = val
+    SET_CONSENT_STATEMENT(state, { field, value }) {
+      if (Object.prototype.hasOwnProperty.call(state.consent, field)) {
+        state.consent[field] = value
+      }
+    },
+    SET_KONDISI_RUMAH_FIELD(state, { field, value }) {
+      if (Object.prototype.hasOwnProperty.call(state.kondisiRumah, field)) {
+        state.kondisiRumah[field] = value
+      }
     },
     SET_DATA_PENGUSUL_FIELD(state, { field, value }) {
       // map common incoming snake_case fields to camelCase store keys
@@ -397,13 +436,24 @@ export default {
     async submitForm({ commit, state }) {
       commit('SET_STATUS_SUBMIT', 'LOADING')
       try {
-        // Build photos from the five document slots in fixed order
-        const docKeys = ['ktp', 'kk', 'suratMiskin', 'suratTanah', 'fotoTanah']
+        // photos[] — urutan tetap: KTP, KK, surat miskin/tidak mampu, surat tanah, lalu 5 sisi foto rumah (depan→kiri→kanan→dalam→belakang); slot opsional yang kosong di-skip
+        const docKeys = [
+          'ktp',
+          'kk',
+          'suratMiskin',
+          'suratTanah',
+          'fotoRumahDepan',
+          'fotoRumahKiri',
+          'fotoRumahKanan',
+          'fotoRumahDalam',
+          'fotoRumahBelakang',
+        ]
         const photos = docKeys
           .map((k) => state.dokumen[k]?.url || '')
           .filter((u) => !!u)
           .map((url) => ({ url }))
 
+        // Field `kondisiRumah` (penyebab/deskripsi/ceklis) belum dikirim — tunggu kontrak API (§6 dokumen rencana).
         const { location, place, cityId, cityName, districtId, districtName, villageId, villageName, dusun, rw, rt, addressDetail } = state.lokasiTanah
         const payload = {
           user_name: state.dataPengusul.name,

--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -7,6 +7,8 @@ export const IMAH_AING_DEFAULT_LOCATION = {
 }
 
 const getDefaultState = () => ({
+  /** Partner API token (Keycloak); sama pola dengan jalan-aing / citizenComplaintForm */
+  authToken: null,
   /** Dari query `source_id` (mis. sapawarga), diisi saat `initForm` */
   sourceId: '',
   currentFormStep: 0,
@@ -155,6 +157,8 @@ export default {
   namespaced: true,
   state: getDefaultState(),
   getters: {
+    authToken: (state) => state.authToken,
+    hasAuthToken: (state) => !!state.authToken,
     currentFormStep: (state) => state.currentFormStep,
     isFirstStep: (state, getters) => state.currentFormStep === getters.startStep,
     isLastStep: (state) => state.currentFormStep === 4,
@@ -188,6 +192,9 @@ export default {
     },
   },
   mutations: {
+    SET_AUTH_TOKEN(state, token) {
+      state.authToken = token
+    },
     SET_SOURCE_ID(state, id) {
       state.sourceId = id || ''
     },
@@ -254,6 +261,20 @@ export default {
     },
   },
   actions: {
+    setAuthToken({ commit }, token) {
+      commit('SET_AUTH_TOKEN', token)
+    },
+    async refreshToken({ state }) {
+      try {
+        const newToken = await this.$getToken('refresh_token')
+        state.authToken = newToken
+        return newToken
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Token refresh failed:', error)
+        throw error
+      }
+    },
     initForm({ commit }, payload) {
       const { meta, sourceId } = normalizeInitQueryPayload(payload)
       commit('SET_SOURCE_ID', sourceId)
@@ -417,7 +438,21 @@ export default {
           data: base64Data,
         }
 
-        const response = await this.$axios.post('/file/upload', formData)
+        let response
+        try {
+          response = await this.$axios.post('/file/upload', formData)
+        } catch (error) {
+          if (error.response?.status === 401) {
+            await dispatch('refreshToken')
+            response = await this.$axios.post('/file/upload', formData, {
+              headers: {
+                Authorization: `Bearer ${state.authToken}`,
+              },
+            })
+          } else {
+            throw error
+          }
+        }
 
         const fileUrl = `${this.$config.urlFile}/${response.data.data.path}`
 
@@ -433,7 +468,7 @@ export default {
         throw error
       }
     },
-    async submitForm({ commit, state }) {
+    async submitForm({ commit, state, dispatch }) {
       commit('SET_STATUS_SUBMIT', 'LOADING')
       try {
         // photos[] — urutan tetap: KTP, KK, surat miskin/tidak mampu, surat tanah, lalu 5 sisi foto rumah (depan→kiri→kanan→dalam→belakang); slot opsional yang kosong di-skip
@@ -482,10 +517,28 @@ export default {
           RW: String(rw || ''),
         }
 
-        const response =
-          this.$config.useMockImahAing && this.$imahAingMock
-            ? await this.$imahAingMock.submitForm(payload)
-            : await this.$axios.post('/v1/aduan/complaints', payload)
+        const postComplaint = () =>
+          this.$axios.post('/aduan/complaints', payload, {
+            headers: state.authToken
+              ? { Authorization: `Bearer ${state.authToken}` }
+              : {},
+          })
+
+        let response
+        if (this.$config.useMockImahAing && this.$imahAingMock) {
+          response = await this.$imahAingMock.submitForm(payload)
+        } else {
+          try {
+            response = await postComplaint()
+          } catch (error) {
+            if (error.response?.status === 401) {
+              await dispatch('refreshToken')
+              response = await postComplaint()
+            } else {
+              throw error
+            }
+          }
+        }
         const submissionId = response.data?.data?.id || response.data?.id || ''
 
         commit('SET_STATUS_SUBMIT', 'SUCCESS')


### PR DESCRIPTION
## FEAT
- Penyesuaian copywriting dan alur persetujuan (consent) di langkah 1 form Imah Aing, termasuk pernyataan terpisah untuk sumber Sapawarga vs warga biasa.
- Dokumen unggahan diperluas: lima sisi foto rumah (wajib hanya depan; sisanya opsional), daftar dokumen dan label langkah diperbarui.
- Bagian **Kondisi rumah** di langkah 3: penyebab kerusakan, deskripsi, dan pernyataan kepemilikan tunggal bermaterai (state di store; bagian payload API mengikuti kontrak terpisah).
- Integrasi API: token Keycloak (`client_credentials`), header `Authorization` untuk upload file dan submit aduan, retry pada 401 dengan refresh token; endpoint submit ke `/aduan/complaints`.

## Related
- 

## Overview
PR ini menggabungkan perbaikan **feedback produk/copy** pada form bantuan perumahan Imah Aing dan **konfigurasi integrasi backend** (autentikasi partner, upload, pengiriman pengaduan). Alur validasi consent diselaraskan dengan tiga pernyataan wajib; dokumen foto diganti dari satu slot “foto tanah” menjadi lima slot foto rumah dengan aturan required/opsional; halaman form mengambil token saat belum ada agar panggilan API terautentikasi.

## Changes
- **StepOne.vue**: Menghapus paragraf proses rekomendasi; memperbarui daftar persyaratan dokumen; checkbox kebijakan privasi + tiga pernyataan (`stmtSingleHouse`, `stmtNoSimilarProgram`, `stmtRevocationIfUntrue`) dengan teks bervariasi menurut `source_id` Sapawarga.
- **StepThree.vue**: Indikator required opsional per dokumen; section kondisi rumah (select, teks “lainnya”, textarea, checkbox); integrasi ke store `kondisiRumah`.
- **StepTwo.vue**, **Stepper.vue**: Penyesuaian minor mengikuti perubahan alur/copy.
- **pages/imah-aing/form/index.vue**: Judul langkah 2 menjadi “Calon Penerima Bantuan”; pemanggilan `$getToken('client_credentials')` dan `setAuthToken` saat mount dan saat kembali ke form jika belum ada token.
- **store/imah-aing/imahAingForm.js**: State `authToken`, getters, mutasi consent & `kondisiRumah`, slot dokumen foto rumah, `isConsentValid` / `isAllDocumentsUploaded`, upload dengan retry 401 + refresh token, `submitForm` ke `/aduan/complaints` dengan Bearer dan retry 401.

## Preview
- 

## Evidence
title: Imah Aing — feedback form & integrasi API  
project: Sapawarga  
participants:  @ekadhirapratama 
screenshot: https://s.digitalservice.id/ZUnCXq
