### PR TITLE
fix: remove privacy policy consent

### DIFF
--- a/components/ImahAing/Form/StepOne.vue
+++ b/components/ImahAing/Form/StepOne.vue
@@ -22,23 +22,11 @@
         <li>Kartu Keluarga (KK);</li>
         <li>Surat Keterangan Miskin / Tidak Mampu dari RT;</li>
         <li>Surat Keterangan Kepemilikan Tanah Dari Kepala Desa/Lurah; dan</li>
-        <li>Foto rumah.</li>
+        <li>Foto Rumah.</li>
       </ol>
     </div>
 
     <div class="flex flex-col gap-4 mt-8">
-      <label class="flex items-center gap-3 cursor-pointer">
-        <input
-          v-model="privacyAccepted"
-          type="checkbox"
-          class="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-        />
-        <span class="text-sm">
-          Saya menyatakan telah membaca, mempelajari, dan menyetujui
-          <a href="https://sapawarga.digitalservice.id/kebijakan-privasi-ketentuan-pengguna" class="underline hover:text-blue-600">Kebijakan Privasi</a>
-        </span>
-      </label>
-
       <label class="flex items-start gap-3 cursor-pointer">
         <input
           v-model="stmtSingleHouse"
@@ -89,14 +77,6 @@ export default {
       return this.isSapawargaSource
         ? 'Saya menyatakan bahwa calon penerima bantuan bersedia dibatalkan jika data dan pernyataan yang saya berikan tidak benar'
         : 'Saya bersedia dibatalkan pengajuannya jika data dan pernyataan yang saya berikan tidak benar'
-    },
-    privacyAccepted: {
-      get() {
-        return this.$store.state.imahAingForm.consent.hasReadPrivacyPolicy
-      },
-      set(val) {
-        this.$store.commit('imahAingForm/SET_CONSENT_PRIVACY', val)
-      },
     },
     stmtSingleHouse: {
       get() {

--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -14,7 +14,6 @@ const getDefaultState = () => ({
   currentFormStep: 0,
 
   consent: {
-    hasReadPrivacyPolicy: false,
     /** Tiga pernyataan — teks UI beda sapawarga vs warga di StepOne */
     stmtSingleHouse: false,
     stmtNoSimilarProgram: false,
@@ -165,12 +164,7 @@ export default {
     startStep: () => 1,
     isConsentValid: (state) => {
       const c = state.consent
-      return (
-        c.hasReadPrivacyPolicy &&
-        c.stmtSingleHouse &&
-        c.stmtNoSimilarProgram &&
-        c.stmtRevocationIfUntrue
-      )
+      return c.stmtSingleHouse && c.stmtNoSimilarProgram && c.stmtRevocationIfUntrue
     },
     isAllDocumentsUploaded: (state) => {
       const requiredKeys = ['ktp', 'kk', 'suratMiskin', 'suratTanah', 'fotoRumahDepan']
@@ -200,9 +194,6 @@ export default {
     },
     SET_CURRENT_FORM_STEP(state, step) {
       state.currentFormStep = step
-    },
-    SET_CONSENT_PRIVACY(state, val) {
-      state.consent.hasReadPrivacyPolicy = val
     },
     SET_CONSENT_STATEMENT(state, { field, value }) {
       if (Object.prototype.hasOwnProperty.call(state.consent, field)) {


### PR DESCRIPTION
## FEAT
- Form Imah Aing (step Perhatian): checkbox persetujuan Kebijakan Privasi disembunyikan dan tidak lagi menjadi syarat untuk melanjutkan ke step berikutnya.

## Related
- 

## Overview
Pull request ini menyesuaikan alur consent di halaman pengajuan Imah Aing: pengguna hanya perlu mencentang tiga pernyataan (rumah tunggal, belum program serupa, bersedia dibatalkan jika data tidak benar). State dan validasi terkait persetujuan kebijakan privasi dihapus karena tidak dipakai di UI maupun di payload submit ke API.

## Changes
- `components/ImahAing/Form/StepOne.vue`: menghapus blok checkbox + link Kebijakan Privasi dan computed `privacyAccepted`.
- `store/imah-aing/imahAingForm.js`: menghapus `hasReadPrivacyPolicy` dari `consent`, memperbarui getter `isConsentValid` agar hanya memeriksa tiga pernyataan, dan menghapus mutasi `SET_CONSENT_PRIVACY`.

## Preview
- 

## Evidence
title: Perubahan checkbox form imah aing
project: Sapawarga  
participants: @ekadhirapratama 
screenshot: https://s.digitalservice.id/XsRdBr