### PR TITLE
fix: form categorization, checkbox styling, and submit copywriting

### DIFF
--- a/components/ImahAing/Form/StepOne.vue
+++ b/components/ImahAing/Form/StepOne.vue
@@ -31,7 +31,7 @@
         <input
           v-model="privacyAccepted"
           type="checkbox"
-          class="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+          class="w-5 h-5 mt-0.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 flex-shrink-0"
         />
         <span class="text-sm">
           Saya menyatakan telah membaca dan mempelajari

--- a/components/ImahAing/Form/StepThree.vue
+++ b/components/ImahAing/Form/StepThree.vue
@@ -190,7 +190,7 @@
 import { mapActions, mapState } from 'vuex'
 
 /** Value `complaint_subcategory_id` untuk opsi "Lainnya" — harus sama dengan `buildImahAingDescription` di store. */
-const PENYEBAB_LAINNYA_VALUE = 'imah-aing-lainnya'
+const PENYEBAB_LAINNYA_VALUE = 'imah-aing-other'
 
 export default {
   data() {

--- a/pages/imah-aing/form/index.vue
+++ b/pages/imah-aing/form/index.vue
@@ -207,8 +207,7 @@ export default {
       return false
     },
     successDescription() {
-      const submissionId = this.statusSubmitForm.complaint_number || '-'
-      return `Pengajuan sudah berhasil dilakukan dengan ID: ${submissionId}. Pastikan warga mencatat ID pengajuan tersebut. Warga dapat melakukan pengecekan status pengajuan melalui Hotline Jabar di Nomor WhatsApp 082126030038.`
+      return 'Pengajuan sudah berhasil dilakukan. Warga dapat melakukan pengecekan pengajuan melalui Hotline Jabar di Nomor WhatsApp 082126030038.'
     },
   },
   created() {

--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -69,7 +69,7 @@ const getDefaultState = () => ({
   },
 })
 
-const IMAH_AING_PENYEBAB_LAINNYA = 'imah-aing-lainnya'
+const IMAH_AING_PENYEBAB_LAINNYA = 'imah-aing-other'
 
 function buildImahAingDescription(kondisiRumah) {
   const deskripsi = String(kondisiRumah?.deskripsiKondisi || '').trim()


### PR DESCRIPTION
## FEAT

- Penyesuaian nilai kategori penyebab "Lainnya" agar konsisten antara form Imah Aing dan store (`imah-aing-other`).
- Perbaikan alignment checkbox persetujuan privasi di Step One (margin atas + tidak menyusut di layout flex).
- Copywriting pesan sukses setelah submit: teks lebih ringkas, tanpa menampilkan ID pengajuan di deskripsi sukses.

## Related
- 

## Overview

PR ini memperbaiki alur form Imah Aing: konstanta "penyebab lainnya" diselaraskan di StepThree dan store, checkbox privasi diperhalus secara visual, dan teks konfirmasi sukses setelah pengajuan disederhanakan agar fokus ke cara cek status lewat Hotline Jabar.

## Changes
- `store/imah-aing/imahAingForm.js` — `IMAH_AING_PENYEBAB_LAINNYA`: `imah-aing-lainnya` → `imah-aing-other`
- `components/ImahAing/Form/StepThree.vue` — `PENYEBAB_LAINNYA_VALUE` disamakan dengan store
- `components/ImahAing/Form/StepOne.vue` — class checkbox: tambah `mt-0.5`, `flex-shrink-0`
- `pages/imah-aing/form/index.vue` — `successDescription` disederhanakan (tanpa interpolasi `complaint_number`)

## Preview
- 

## Evidence
title: Fix Imah Aing form categorization, checkbox styling, and submit copywriting
project: Sapawarga
participants: @ekadhirapratama 
screenshot: https://s.digitalservice.id/dHj7Pd