### PR TITLE
feat: add field income per month & cuase option adjustment

### DIFF
--- a/components/ImahAing/Form/StepThree.vue
+++ b/components/ImahAing/Form/StepThree.vue
@@ -131,30 +131,6 @@
         </ValidationProvider>
 
         <ValidationProvider
-          v-if="isPenyebabLainnya"
-          v-slot="{ errors }"
-          rules="required"
-          name="Penyebab lainnya"
-          class="flex flex-col gap-2"
-          tag="div"
-        >
-          <label
-            for="penyebabLainnya"
-            class="text-sm font-medium text-black font-roboto dark:text-dark-emphasis-high"
-          >
-            Penyebab lainnya <span class="text-red-500">*</span>
-          </label>
-          <JdsInputText
-            id="penyebabLainnya"
-            :value="setPenyebabKerusakanLainnya"
-            class="w-full"
-            placeholder="Jelaskan penyebab lainnya"
-            :error-message="errors[0]"
-            @input="setPenyebabKerusakanLainnya = $event"
-          />
-        </ValidationProvider>
-
-        <ValidationProvider
           v-slot="{ errors }"
           rules="required"
           name="Deskripsi kondisi rumah"
@@ -189,9 +165,6 @@
 <script>
 import { mapActions, mapState } from 'vuex'
 
-/** Value `complaint_subcategory_id` untuk opsi "Lainnya" — harus sama dengan `buildImahAingDescription` di store. */
-const PENYEBAB_LAINNYA_VALUE = 'imah-aing-other'
-
 export default {
   data() {
     return {
@@ -219,11 +192,8 @@ export default {
         },
       ],
       penyebabOptions: [
-        { value: 'imah-aing-usia-bangunan', label: 'Usia Bangunan' },
-        { value: 'imah-aing-gagal-konstruksi', label: 'Tidak Sesuai Kaidah Teknis' },
-        { value: 'imah-aing-kebakaran', label: 'Kebakaran' },
-        { value: 'imah-aing-bencana', label: 'Bencana Alam' },
-        { value: PENYEBAB_LAINNYA_VALUE, label: 'Lainnya' },
+        { value: 'imah-aing-bencana', label: 'Bencana' },
+        { value: 'imah-aing-non-bencana', label: 'Bukan Bencana' },
       ],
       accept: '.jpg, .jpeg, .png, .pdf',
       maxSize: 2 * 1024 * 1024, // 2 MB
@@ -240,9 +210,6 @@ export default {
     hasUploadError() {
       return (key) => !!(this.dokumen?.[key]?.errors && this.dokumen[key].errors.length > 0)
     },
-    isPenyebabLainnya() {
-      return this.kondisiRumah.penyebabKerusakan === PENYEBAB_LAINNYA_VALUE
-    },
     setPenyebabKerusakan: {
       get() {
         return this.kondisiRumah.penyebabKerusakan || ''
@@ -250,22 +217,9 @@ export default {
       set(val) {
         const v = val != null ? String(val) : ''
         this.$store.commit('imahAingForm/SET_KONDISI_RUMAH_FIELD', { field: 'penyebabKerusakan', value: v })
-        if (v !== PENYEBAB_LAINNYA_VALUE) {
-          this.$store.commit('imahAingForm/SET_KONDISI_RUMAH_FIELD', {
-            field: 'penyebabKerusakanLainnya',
-            value: '',
-          })
-        }
-      },
-    },
-    setPenyebabKerusakanLainnya: {
-      get() {
-        return this.kondisiRumah.penyebabKerusakanLainnya
-      },
-      set(val) {
         this.$store.commit('imahAingForm/SET_KONDISI_RUMAH_FIELD', {
           field: 'penyebabKerusakanLainnya',
-          value: val,
+          value: '',
         })
       },
     },

--- a/components/ImahAing/Form/StepTwo.vue
+++ b/components/ImahAing/Form/StepTwo.vue
@@ -76,6 +76,30 @@
         :error-message="errors[0] || kkDuplicateMessage"
       />
     </ValidationProvider>
+
+    <!-- Pendapatan per Bulan — WAJIB; digit-only via keydown + sanitasi @input; tampilan ribuan id-ID -->
+    <ValidationProvider
+      v-slot="{ errors }"
+      class="flex flex-col gap-2 mb-5"
+      rules="required"
+      name="Pendapatan per Bulan"
+      vid="incomePerMonth"
+      :value="incomeDigitsRaw"
+    >
+      <BaseInputText
+        :value="formatIncomeIdDisplay(incomeDigitsRaw)"
+        class="step-two-input-jds"
+        type="text"
+        label="Pendapatan per Bulan"
+        required
+        :placeholder="zwsPlaceholder"
+        autocomplete="off"
+        :error="!!errors[0]"
+        :error-message="errors[0]"
+        @input="onIncomePerMonthInput"
+        @keydown.native="onIncomePerMonthKeydown"
+      />
+    </ValidationProvider>
     </section>
   </ValidationObserver>
 </template>
@@ -129,6 +153,10 @@ export default {
         this.$store.commit('imahAingForm/SET_DATA_PENGUSUL_FIELD', { field: 'nomorKk', value: digits })
       },
     },
+    /** Digit murni di Vuex — dipakai `ValidationProvider` `:value` + formatter tampilan. */
+    incomeDigitsRaw() {
+      return this.$store.state.imahAingForm.dataPengusul.incomePerMonth
+    },
     setName: {
       get() {
         return this.$store.state.imahAingForm.dataPengusul.name
@@ -152,6 +180,57 @@ export default {
     },
   },
   methods: {
+    /**
+     * Tampilan berpemisah ribuan (id-ID). Hanya digit 0–9 dari argumen yang dipakai;
+     * huruf dan karakter lain dibuang (sama seperti alur input).
+     */
+    formatIncomeIdDisplay(digitStr) {
+      const core = String(digitStr ?? '').replace(/\D/g, '')
+      if (core === '') {
+        return ''
+      }
+      const trimmed = core.replace(/^0+(?=\d)/, '') || '0'
+      const n = Number(trimmed)
+      if (!Number.isFinite(n)) {
+        return ''
+      }
+      return new Intl.NumberFormat('id-ID').format(n)
+    },
+    onIncomePerMonthInput(val) {
+      const digitsOnly = String(val ?? '').replace(/\D/g, '')
+      const normalized =
+        digitsOnly === '' ? '' : (digitsOnly.replace(/^0+(?=\d)/, '') || '0')
+      this.$store.commit('imahAingForm/SET_DATA_PENGUSUL_FIELD', {
+        field: 'incomePerMonth',
+        value: normalized,
+      })
+    },
+    /** Cegah huruf/simbol di keydown agar tidak sempat tampil di input terkontrol. */
+    onIncomePerMonthKeydown(e) {
+      if (e.ctrlKey || e.metaKey || e.altKey) {
+        return
+      }
+      const allowed = new Set([
+        'Backspace',
+        'Delete',
+        'Tab',
+        'Escape',
+        'Enter',
+        'ArrowLeft',
+        'ArrowRight',
+        'ArrowUp',
+        'ArrowDown',
+        'Home',
+        'End',
+      ])
+      if (allowed.has(e.key)) {
+        return
+      }
+      if (e.key.length === 1 && e.key >= '0' && e.key <= '9') {
+        return
+      }
+      e.preventDefault()
+    },
     clearKkDuplicateMessage() {
       this.kkDuplicateMessage = ''
     },

--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -70,8 +70,6 @@ const getDefaultState = () => ({
   },
 })
 
-const IMAH_AING_PENYEBAB_LAINNYA = 'imah-aing-other'
-
 const USER_INCOME_PER_MONTH_KEY = 'user_income_per_month'
 
 function incomeDigitsToNumber(digits) {
@@ -84,12 +82,7 @@ function incomeDigitsToNumber(digits) {
 }
 
 function buildImahAingDescription(kondisiRumah) {
-  const deskripsi = String(kondisiRumah?.deskripsiKondisi || '').trim()
-  const penyebabLainnya = String(kondisiRumah?.penyebabKerusakanLainnya || '').trim()
-  if (kondisiRumah?.penyebabKerusakan === IMAH_AING_PENYEBAB_LAINNYA && penyebabLainnya) {
-    return `[Penyebab lainnya: ${penyebabLainnya}] ${deskripsi}`.trim()
-  }
-  return deskripsi
+  return String(kondisiRumah?.deskripsiKondisi || '').trim()
 }
 
 function parseComplaintExistsResponse(response) {

--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -32,6 +32,7 @@ const getDefaultState = () => ({
     email: '',
     nik: '',
     nomorKk: '',
+    incomePerMonth: '',
     avatarUrl: '',
   },
 
@@ -70,6 +71,17 @@ const getDefaultState = () => ({
 })
 
 const IMAH_AING_PENYEBAB_LAINNYA = 'imah-aing-other'
+
+const USER_INCOME_PER_MONTH_KEY = 'user_income_per_month'
+
+function incomeDigitsToNumber(digits) {
+  const s = String(digits || '').replace(/\D/g, '')
+  if (s === '') {
+    return NaN
+  }
+  const n = Number(s)
+  return Number.isFinite(n) && n >= 0 ? n : NaN
+}
 
 function buildImahAingDescription(kondisiRumah) {
   const deskripsi = String(kondisiRumah?.deskripsiKondisi || '').trim()
@@ -574,12 +586,19 @@ export default {
         const photos = [...baseUrls, ...fotoUrls].map((url) => ({ url }))
 
         const { location, place, cityId, cityName, districtId, districtName, villageId, villageName, dusun, rw, rt, addressDetail } = state.lokasiTanah
+        const userIncomePerMonth = incomeDigitsToNumber(state.dataPengusul.incomePerMonth)
+        if (!Number.isFinite(userIncomePerMonth)) {
+          commit('SET_STATUS_SUBMIT', 'ERROR')
+          throw new Error('invalid_user_income_per_month')
+        }
+
         const payload = {
           user_name: state.dataPengusul.name,
           user_email: state.dataPengusul.email || '',
           user_phone: state.dataPengusul.phone,
           user_nik: state.dataPengusul.nik,
           user_kk: state.dataPengusul.nomorKk,
+          [USER_INCOME_PER_MONTH_KEY]: userIncomePerMonth,
           source_id: state.sourceId || 'sapawarga',
           type: 'private',
           photos,


### PR DESCRIPTION
## FEAT
- Field wajib **Pendapatan per Bulan** di form Imah Aing (Step 2): input digit, format tampilan ribuan `id-ID`, validasi di submit.
- Penyebab kerusakan di Step 3 disederhanakan menjadi **Bencana** / **Bukan Bencana** (mengganti opsi lama termasuk "Lainnya").
- Menghapus input **Penyebab lainnya** dan logika penyusunan deskripsi yang menyisipkan teks penyebab lainnya.

## Related
- [Task number 27, 28, 29](https://docs.google.com/spreadsheets/d/1APrma05qnRBqLbfAkUyl4FScL7lPJ2oGiGZYXUnkkc0/edit?gid=2069695550#gid=2069695550)

## Overview
PR ini memperbarui alur form **Imah Aing**: pengguna wajib mengisi pendapatan bulanan di langkah data pengusul; nilai dikirim ke backend sebagai `user_income_per_month` pada payload submit. Di langkah kondisi rumah, daftar penyebab kerusakan dan UX "lainnya" disesuaikan agar hanya dua kategori besar, tanpa field teks tambahan.

## Changes
- `components/ImahAing/Form/StepTwo.vue`: field Pendapatan per Bulan (`ValidationProvider`, formatter, keydown digit-only).
- `store/imah-aing/imahAingForm.js`: state `dataPengusul.incomePerMonth`, helper `incomeDigitsToNumber`, validasi sebelum submit, field payload `user_income_per_month`; `buildImahAingDescription` hanya memakai deskripsi kondisi (tanpa prefix penyebab lainnya).
- `components/ImahAing/Form/StepThree.vue`: opsi penyebab baru, hapus UI & computed terkait "Lainnya".

## Preview
- 

## Evidence
title: Form Imah Aing - penambahan field income per month dan penyesuaian option
project: Sapawarga
participants: @ekadhirapratama 
screenshot: https://s.digitalservice.id/zmFWxw
