### PR TITLE
feat: add session expiration handling in imah-aing form

### DIFF
--- a/pages/imah-aing/form/index.vue
+++ b/pages/imah-aing/form/index.vue
@@ -147,6 +147,18 @@
       @close="cancelSubmit"
       @click="retrySubmitComplaintForm"
     />
+
+    <TrackingComplaintModal
+      :open="statusSubmitForm.status === 'SESSION_EXPIRED'"
+      header="Sesi Anda Telah Habis"
+      label-primary-button="Masuk Kembali"
+      label-secondary-button="Tutup"
+      name-icon="warning"
+      size="16px"
+      description="Maaf, sesi Anda telah habis. Untuk melanjutkan, silakan masuk kembali dan kirim ulang pengajuan Anda."
+      @close="handleSessionExpired"
+      @click="handleSessionExpired"
+    />
   </div>
 </template>
 
@@ -256,6 +268,9 @@ export default {
             return
           }
         } catch {
+          if (this.statusSubmitForm.status === 'SESSION_EXPIRED') {
+            return
+          }
           this.$refs.stepTwo.setKkDuplicateMessage('Gagal memverifikasi No KK. Silakan coba lagi.')
           return
         }
@@ -320,6 +335,11 @@ export default {
       setTimeout(() => {
         this.isLoading = false
       }, 1500)
+    },
+    handleSessionExpired() {
+      if (process.client) {
+        window.location.reload()
+      }
     },
   },
 }

--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -115,6 +115,10 @@ function parseComplaintExistsResponse(response) {
   return false
 }
 
+function isUnauthorizedError(error) {
+  return error?.response?.status === 401
+}
+
 /** Base64url-safe JSON dari query `meta` (UTF-8) */
 function decodeMetaQueryParam(encoded) {
   if (!encoded || typeof encoded !== 'string' || typeof atob === 'undefined') {
@@ -319,17 +323,6 @@ export default {
     setAuthToken({ commit }, token) {
       commit('SET_AUTH_TOKEN', token)
     },
-    async refreshToken({ state }) {
-      try {
-        const newToken = await this.$getToken('refresh_token')
-        state.authToken = newToken
-        return newToken
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error('Token refresh failed:', error)
-        throw error
-      }
-    },
     initForm({ commit }, payload) {
       const { meta, sourceId } = normalizeInitQueryPayload(payload)
       commit('SET_SOURCE_ID', sourceId)
@@ -385,7 +378,7 @@ export default {
      * Cek apakah KK sudah punya pengajuan Imah Aing (double submission).
      * @returns {Promise<boolean>} `true` jika sudah ada pengajuan.
      */
-    async checkKkDuplicate({ state, dispatch }) {
+    async checkKkDuplicate({ state, commit }) {
       const kk = String(state.dataPengusul.nomorKk || '').replace(/\D/g, '')
       if (!kk) {
         return false
@@ -411,10 +404,8 @@ export default {
         const res = await call()
         return parseComplaintExistsResponse(res)
       } catch (error) {
-        if (error.response?.status === 401) {
-          await dispatch('refreshToken')
-          const res = await call()
-          return parseComplaintExistsResponse(res)
+        if (isUnauthorizedError(error)) {
+          commit('SET_STATUS_SUBMIT', 'SESSION_EXPIRED')
         }
         throw error
       }
@@ -546,16 +537,10 @@ export default {
         try {
           response = await this.$axios.post('/file/upload', formData)
         } catch (error) {
-          if (error.response?.status === 401) {
-            await dispatch('refreshToken')
-            response = await this.$axios.post('/file/upload', formData, {
-              headers: {
-                Authorization: `Bearer ${state.authToken}`,
-              },
-            })
-          } else {
-            throw error
+          if (isUnauthorizedError(error)) {
+            commit('SET_STATUS_SUBMIT', 'SESSION_EXPIRED')
           }
+          throw error
         }
 
         const fileUrl = `${this.$config.urlFile}/${response.data.data.path}`
@@ -569,7 +554,7 @@ export default {
         throw error
       }
     },
-    async submitForm({ commit, state, dispatch }) {
+    async submitForm({ commit, state }) {
       commit('SET_STATUS_SUBMIT', 'LOADING')
       try {
         // photos[] — urutan: KTP, KK, surat miskin, surat tanah, lalu semua foto rumah (multifile)
@@ -628,12 +613,10 @@ export default {
           try {
             response = await postComplaint()
           } catch (error) {
-            if (error.response?.status === 401) {
-              await dispatch('refreshToken')
-              response = await postComplaint()
-            } else {
-              throw error
+            if (isUnauthorizedError(error)) {
+              commit('SET_STATUS_SUBMIT', 'SESSION_EXPIRED')
             }
+            throw error
           }
         }
         const submissionId = response.data?.data?.id || response.data?.id || ''
@@ -642,7 +625,9 @@ export default {
         commit('SET_SUBMISSION_ID', submissionId)
         return response
       } catch (error) {
-        commit('SET_STATUS_SUBMIT', 'ERROR')
+        if (state.statusSubmitForm.status !== 'SESSION_EXPIRED') {
+          commit('SET_STATUS_SUBMIT', 'ERROR')
+        }
         throw error
       }
     },


### PR DESCRIPTION
## FEAT
- Penanganan sesi habis (401) pada alur formulir Imah Aing: modal informasi dan arahan masuk kembali, tanpa retry otomatis setelah refresh token.
- Status submit baru `SESSION_EXPIRED` agar UI bisa membedakan error umum vs sesi berakhir.

## Related
- [Task No 18](https://docs.google.com/spreadsheets/d/1APrma05qnRBqLbfAkUyl4FScL7lPJ2oGiGZYXUnkkc0/edit?gid=2069695550#gid=2069695550)

## Overview
Pull request ini mengganti strategi saat API mengembalikan 401 pada formulir Imah Aing. Sebelumnya store mencoba `refreshToken` dan mengulang request. Sekarang, untuk cek duplikasi KK, upload file, dan submit pengaduan, respons 401 men-set status `SESSION_EXPIRED`. Halaman form menampilkan modal `TrackingComplaintModal` dengan pesan sesi habis; pengguna bisa menutup atau masuk kembali, lalu halaman di-reload agar bisa login ulang. Di verifikasi KK, error generik tidak menimpa alur jika status sudah `SESSION_EXPIRED`. Action `refreshToken` di store dihapus karena tidak lagi dipakai di jalur ini.

## Changes
- `store/imah-aing/imahAingForm.js`: helper `isUnauthorizedError`, hapus action `refreshToken`, pada `checkKkDuplicate` / upload / `submitForm` set `SESSION_EXPIRED` saat 401; hindari overwrite ke `ERROR` jika sudah session expired.
- `pages/imah-aing/form/index.vue`: modal sesi habis, `handleSessionExpired` (reload di client), early return di catch verifikasi KK saat status session expired.

## Preview
- 

## Evidence
title: Perubahan copywriting sesi habis pada form Imah Aing  
project: Sapawarga  
participants: @ekadhirapratama 
screenshot: https://s.digitalservice.id/w5AOw9