### PR TITLE
fix: ganti opsi penyebab RTLH + inline info box

### DIFF
--- a/components/ImahAing/Form/StepOne.vue
+++ b/components/ImahAing/Form/StepOne.vue
@@ -83,7 +83,7 @@ export default {
     },
     copySingleHouse() {
       return this.isSapawargaSource
-        ? 'Saya menyatakan bahwa rumah yang diajukan merupakan rumah tunggal calon penerima bantuan'
+        ? 'Saya menyatakan bahwa rumah yang diajukan merupakan rumah satu-satunya calon penerima bantuan'
         : 'Saya menyatakan bahwa rumah yang diajukan merupakan rumah satu-satunya saya'
     },
     copyNoSimilarProgram() {

--- a/components/ImahAing/Form/StepThree.vue
+++ b/components/ImahAing/Form/StepThree.vue
@@ -130,6 +130,14 @@
           />
         </ValidationProvider>
 
+        <div
+          v-if="selectedPenyebabDetail"
+          class="info-box"
+        >
+          <div class="info-box-title">{{ selectedPenyebabDetail.title }}</div>
+          <div class="info-box-desc">{{ selectedPenyebabDetail.desc }}</div>
+        </div>
+
         <ValidationProvider
           v-slot="{ errors }"
           rules="required"
@@ -192,9 +200,29 @@ export default {
         },
       ],
       penyebabOptions: [
-        { value: 'imah-aing-bencana', label: 'Bencana' },
-        { value: 'imah-aing-non-bencana', label: 'Bukan Bencana' },
+        { value: 'imah-aing-bangunan-tua', label: 'Usia bangunan tua' },
+        { value: 'imah-aing-kesalahan-konstruksi', label: 'Kesalahan konstruksi' },
+        { value: 'imah-aing-perawatan-buruk', label: 'Perawatan yang buruk' },
+        { value: 'imah-aing-hama-jamur', label: 'Hama dan jamur' },
       ],
+      penyebabDetailMap: {
+        'imah-aing-bangunan-tua': {
+          title: 'Usia bangunan tua',
+          desc: 'Material lapuk, retak, atau struktur melemah karena kurang perawatan seiring bertambahnya usia bangunan.',
+        },
+        'imah-aing-kesalahan-konstruksi': {
+          title: 'Kesalahan konstruksi',
+          desc: 'Penggunaan material berkualitas rendah, fondasi tidak sesuai standar, atau desain yang tidak kokoh saat pembangunan.',
+        },
+        'imah-aing-perawatan-buruk': {
+          title: 'Perawatan yang buruk',
+          desc: 'Kebocoran atap tidak diperbaiki, dinding retak dibiarkan, atau saluran air tersumbat dalam jangka panjang.',
+        },
+        'imah-aing-hama-jamur': {
+          title: 'Hama dan jamur',
+          desc: 'Rayap merusak kayu struktur bangunan, jamur melapukkan dinding atau plafon sehingga melemahkan integritas bangunan.',
+        },
+      },
       accept: '.jpg, .jpeg, .png, .pdf',
       maxSize: 2 * 1024 * 1024, // 2 MB
     }
@@ -209,6 +237,10 @@ export default {
     },
     hasUploadError() {
       return (key) => !!(this.dokumen?.[key]?.errors && this.dokumen[key].errors.length > 0)
+    },
+    selectedPenyebabDetail() {
+      const key = this.kondisiRumah.penyebabKerusakan
+      return key ? this.penyebabDetailMap[key] : null
     },
     setPenyebabKerusakan: {
       get() {
@@ -363,5 +395,32 @@ export default {
 .slide-fade-leave-to {
   transform: translateY(10px);
   opacity: 0;
+}
+
+/* Info box penyebab */
+.info-box {
+  margin-top: 12px;
+  padding: 14px;
+  background: #F0F9F4;
+  border: 1px solid #D1EADE;
+  border-left: 4px solid #069550;
+  border-radius: 4px 8px 8px 4px;
+  animation: fadeIn 0.2s ease;
+}
+.info-box-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 4px;
+}
+.info-box-desc {
+  font-size: 13px;
+  color: #4B5563;
+  line-height: 1.5;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 </style>


### PR DESCRIPTION
## FEAT
- Mengganti opsi dropdown "Penyebab Rumah Tidak Layak" dari 2 pilihan (Bencana/Bukan Bencana) menjadi 4 opsi deskriptif baru
- Menambahkan info box inline yang menampilkan deskripsi detail penyebab saat opsi dipilih
- Memperbaiki copywriting pernyataan consent di Step 1

## Related
- Backlog Feedback No 35 — Opsi Penyebab Rumah Tidak Layak. [Link](https://docs.google.com/spreadsheets/d/1APrma05qnRBqLbfAkUyl4FScL7lPJ2oGiGZYXUnkkc0/edit?gid=2069695550#gid=2069695550&range=D36)

## Overview
PR ini mencakup 2 perubahan pada modul Imah Aing:

1. **Step 3 — Opsi Penyebab RTLH**: Dropdown "Penyebab Rumah Tidak Layak" diganti dari 2 opsi lama menjadi 4 opsi baru yang lebih deskriptif. Setiap opsi memiliki label pendek (tampil di dropdown) dan deskripsi panjang yang muncul di info box hijau (inline) saat opsi dipilih — mengacu pada Variasi A di select_penyebab_rtlh_simulation.html.

2. **Step 1 — Copywriting**: Pernyataan consent untuk pengguna dari sumber `sapawarga` diperbaiki dari "rumah tunggal" menjadi "rumah satu-satunya" agar lebih akurat secara bahasa.

## Changes
### StepThree.vue
| Perubahan | Detail |
|---|---|
| `penyebabOptions` | 2 opsi lama → 4 opsi baru (`imah-aing-bangunan-tua`, `imah-aing-kesalahan-konstruksi`, `imah-aing-perawatan-buruk`, `imah-aing-hama-jamur`) |
| `penyebabDetailMap` (baru) | Mapping value → `{ title, desc }` untuk info box |
| `selectedPenyebabDetail` (baru) | Computed property untuk reaktivitas info box |
| Template info box | Div dengan `v-if="selectedPenyebabDetail"` di antara dropdown dan textarea deskripsi |
| CSS | 3 class baru (`.info-box`, `.info-box-title`, `.info-box-desc`) + animasi `@keyframes fadeIn` |

### StepOne.vue
| Perubahan | Detail |
|---|---|
| `copySingleHouse()` | Copywriting: "rumah tunggal" → "rumah satu-satunya" untuk source sapawarga |

## Preview
![image](https://s.digitalservice.id/CmgnFV)

## Evidence
title: Perbaikan Opsi Penyebab RTLH + Info Box untuk form ImahAing
project: Sapawarga
participants: @ekadhirapratama 
screenshot: https://s.digitalservice.id/Bv04MJ