### PR TITLE
feat(imah-aing): add button to navigate to submission form

### DIFF
--- a/components/ImahAing/Form/StepTwo.vue
+++ b/components/ImahAing/Form/StepTwo.vue
@@ -47,6 +47,7 @@
         type="text"
         label="NIK Calon Penerima Bantuan"
         required
+        :disabled="isEditMode"
         :maxlength="maxNikKkLength"
         :placeholder="zwsPlaceholder"
         autocomplete="off"
@@ -69,6 +70,7 @@
         type="text"
         label="No KK Calon Penerima Bantuan"
         required
+        :disabled="isEditMode"
         :maxlength="maxNikKkLength"
         :placeholder="zwsPlaceholder"
         autocomplete="off"
@@ -105,6 +107,8 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
   data() {
     return {
@@ -114,6 +118,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters('imahAingForm', ['isEditMode']),
     name() {
       return this.$store.state.imahAingForm.dataPengusul.name
     },

--- a/pages/imah-aing/form/index.vue
+++ b/pages/imah-aing/form/index.vue
@@ -238,21 +238,41 @@ export default {
     }
     await this.initForm(this.$route.query)
     this.hydrateLokasiTanahFromGeolocation()
-
-    // Mode edit: hydrate dari data list + set langsung ke Step 2
-    const editId = this.$route.query.edit
-    if (editId) {
-      await this.hydrateFromExisting(editId)
-      this.$store.commit('imahAingForm/SET_CURRENT_FORM_STEP', 2)
-    } else {
-      this.$store.commit('imahAingForm/SET_CURRENT_FORM_STEP', this.startStep)
-    }
+    await this.setupEditOrFirstStep()
   },
   methods: {
+    /**
+     * Mode edit: prefill form lalu langsung ke Step 2. Selain itu mulai dari Step 1.
+     * Baseline diisi dari data list (`hydrateFromExisting` — set consent & editComplaintId),
+     * lalu di-overlay prefill lengkap dari GET detail. Bila GET gagal, baseline tetap dipakai.
+     */
+    async setupEditOrFirstStep() {
+      const editId = this.$route.query.edit
+      if (!editId) {
+        this.$store.commit('imahAingForm/SET_CURRENT_FORM_STEP', this.startStep)
+        return
+      }
+      // Pastikan editComplaintId selalu ter-set saat mode edit —
+      // Ditempatkan sebelum hydrateFromExisting karena hydrateFromExisting hanya
+      // set editComplaintId jika item ditemukan di list (gagal jika akses langsung URL).
+      this.$store.commit('imahAingForm/SET_EDIT_COMPLAINT_ID', editId)
+      await this.hydrateFromExisting(editId)
+      try {
+        const detail = await this.fetchComplaintDetail(editId)
+        if (detail) {
+          this.hydrateFromDetail(detail)
+        }
+      } catch (error) {
+        // GET detail gagal → tetap pakai baseline data list, form bisa dilanjutkan
+      }
+      this.$store.commit('imahAingForm/SET_CURRENT_FORM_STEP', 2)
+    },
     ...mapActions('imahAingForm', {
       initForm: 'initForm',
       hydrateLokasiTanahFromGeolocation: 'hydrateLokasiTanahFromGeolocation',
       hydrateFromExisting: 'hydrateFromExisting',
+      fetchComplaintDetail: 'fetchComplaintDetail',
+      hydrateFromDetail: 'hydrateFromDetail',
       goToNextStep: 'nextStep',
       goToPreviousStep: 'previousStep',
       submitForm: 'submitForm',
@@ -336,14 +356,7 @@ export default {
       }
       await this.initForm(this.$route.query)
       this.hydrateLokasiTanahFromGeolocation()
-
-      const editId = this.$route.query.edit
-      if (editId) {
-        await this.hydrateFromExisting(editId)
-        this.$store.commit('imahAingForm/SET_CURRENT_FORM_STEP', 2)
-      } else {
-        this.$store.commit('imahAingForm/SET_CURRENT_FORM_STEP', this.startStep)
-      }
+      await this.setupEditOrFirstStep()
 
       this.$store.commit('imahAingForm/SET_STATUS_SUBMIT', 'NONE')
     },

--- a/pages/imah-aing/index.vue
+++ b/pages/imah-aing/index.vue
@@ -13,6 +13,13 @@
         <hr class="mt-4 md:mt-5 dark:border-dark-emphasis-medium" />
 
         <div class="px-4 py-4 md:px-7 md:py-5">
+          <!-- Add new submission -->
+          <div class="flex justify-end mb-4">
+            <Button variant="primary" @click="goToForm">
+              + Tambah
+            </Button>
+          </div>
+
           <!-- Loading skeleton -->
           <ImahAingHistorySkeleton v-if="isLoading" />
 
@@ -184,6 +191,13 @@ export default {
 
     redirectToForm() {
       this.$router.replace({
+        path: '/imah-aing/form',
+        query: this.$route.query,
+      })
+    },
+
+    goToForm() {
+      this.$router.push({
         path: '/imah-aing/form',
         query: this.$route.query,
       })

--- a/pages/imah-aing/index.vue
+++ b/pages/imah-aing/index.vue
@@ -208,7 +208,7 @@ export default {
         path: '/imah-aing/form',
         query: {
           ...this.$route.query,
-          edit: item.id,
+          edit: item.complaint_id || item.id,
         },
       })
     },

--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -211,6 +211,8 @@ export default {
     authToken: (state) => state.authToken,
     hasAuthToken: (state) => !!state.authToken,
     currentFormStep: (state) => state.currentFormStep,
+    /** Mode edit aktif jika ada usulan yang sedang diedit (`editComplaintId` terisi). */
+    isEditMode: (state) => !!state.editComplaintId,
     isFirstStep: (state, getters) => state.currentFormStep === getters.startStep,
     isLastStep: (state) => state.currentFormStep === 4,
     startStep: () => 1,
@@ -379,6 +381,122 @@ export default {
       commit('SET_CONSENT_STATEMENT', { field: 'stmtNoSimilarProgram', value: true })
       commit('SET_CONSENT_STATEMENT', { field: 'stmtRevocationIfUntrue', value: true })
     },
+    /**
+     * Ambil detail usulan untuk prefill lengkap di mode edit.
+     * @returns {Promise<object|null>} data detail, atau `null` bila kosong.
+     */
+    async fetchComplaintDetail({ state, commit }, complaintId) {
+      if (!complaintId) {
+        return null
+      }
+      try {
+        const res = await this.$gatewayPartnerAPI.get(`/aduan/complaints/${complaintId}`, {
+          params: { phase: 'verification' },
+          headers: state.authToken ? { Authorization: `Bearer ${state.authToken}` } : {},
+        })
+        return res.data?.data || null
+      } catch (error) {
+        if (isUnauthorizedError(error)) {
+          commit('SET_STATUS_SUBMIT', 'SESSION_EXPIRED')
+        }
+        throw error
+      }
+    },
+    /**
+     * Overlay prefill form dari response GET detail (menimpa baseline list item).
+     * Hanya field yang tersedia di detail yang diisi.
+     */
+    hydrateFromDetail({ commit }, detail) {
+      if (!detail || typeof detail !== 'object') {
+        return
+      }
+
+      // Data pengusul / calon penerima
+      const setPengusul = (field, value) => {
+        if (value != null && String(value).trim() !== '') {
+          commit('SET_DATA_PENGUSUL_FIELD', { field, value: String(value).trim() })
+        }
+      }
+      setPengusul('name', detail.user_name)
+      setPengusul('nik', detail.user_nik)
+      setPengusul('nomorKk', detail.user_kk)
+      setPengusul('phone', detail.user_phone)
+      setPengusul('email', detail.user_email)
+      setPengusul('id', detail.user_id)
+      setPengusul('role', detail.user_role)
+      if (detail.user_income_per_month != null && detail.user_income_per_month !== '') {
+        commit('SET_DATA_PENGUSUL_FIELD', {
+          field: 'incomePerMonth',
+          value: String(detail.user_income_per_month).replace(/\D/g, ''),
+        })
+      }
+
+      // Kondisi rumah
+      if (detail.description != null) {
+        commit('SET_KONDISI_RUMAH_FIELD', { field: 'deskripsiKondisi', value: String(detail.description) })
+      }
+      if (detail.complaint_subcategory_id) {
+        commit('SET_KONDISI_RUMAH_FIELD', { field: 'penyebabKerusakan', value: detail.complaint_subcategory_id })
+      }
+
+      // Lokasi tanah
+      const setLokasi = (field, value) => {
+        if (value != null && String(value).trim() !== '') {
+          commit('SET_LOKASI_TANAH_FIELD', { field, value: String(value).trim() })
+        }
+      }
+      setLokasi('city_id', detail.city_id)
+      setLokasi('city_name', detail.city_name)
+      setLokasi('district_id', detail.district_id)
+      setLokasi('district_name', detail.district_name)
+      setLokasi('village_id', detail.village_id)
+      setLokasi('village_name', detail.village_name)
+      setLokasi('rt', detail.RT)
+      setLokasi('rw', detail.RW)
+      setLokasi('dusun', detail.dusun_name)
+      setLokasi('address_detail', detail.address_detail)
+      if (detail.address != null) {
+        commit('SET_LOKASI_TANAH_FIELD', {
+          field: 'place',
+          value: { name: '', address: String(detail.address) },
+        })
+      }
+      const loc = parseLocationFromMetaPayload(detail)
+      if (loc) {
+        commit('SET_LOKASI_TANAH_FIELD', { field: 'location', value: loc })
+      }
+
+      // Dokumen — map photos[].field → slot store, tandai SUCCESS agar lolos validasi
+      if (Array.isArray(detail.photos)) {
+        const fieldToSlot = {
+          ktp: 'ktp',
+          kk: 'kk',
+          surat_miskin: 'suratMiskin',
+          surat_tanah: 'suratTanah',
+          foto_depan: 'fotoDepan',
+          foto_belakang: 'fotoBelakang',
+          foto_kiri: 'fotoKiri',
+          foto_kanan: 'fotoKanan',
+          foto_dalam: 'fotoDalam',
+        }
+        detail.photos.forEach((photo) => {
+          const slotKey = fieldToSlot[photo?.field]
+          if (slotKey && photo?.url) {
+            // Buat placeholder File agar file.size tidak null di UploadProgress.
+            // Size diambil dari photo.size (jika API menyediakan), fallback ke 0.
+            const fileName = photo.url.split('/').pop().split('?')[0] || 'document'
+            const byteSize = photo.size != null && Number.isFinite(Number(photo.size)) ? Number(photo.size) : 0
+            const placeholderFile = process.client
+              ? new File([new ArrayBuffer(byteSize)], fileName)
+              : null
+            commit('SET_DOKUMEN_SLOT', {
+              key: slotKey,
+              payload: { file: placeholderFile, url: photo.url, progress: 100, status: 'SUCCESS', errors: [] },
+            })
+          }
+        })
+      }
+    },
     hydrateLokasiTanahFromGeolocation({ commit, state }) {
       if (!process.client) {
         return
@@ -423,6 +541,12 @@ export default {
      * @returns {Promise<boolean>} `true` jika sudah ada pengajuan.
      */
     async checkKkDuplicate({ state, commit }) {
+      // Mode edit: KK milik usulan yang sedang diedit — lewati cek duplikat
+      // agar tidak salah memblokir dengan "No KK Sudah Pernah Diajukan".
+      if (state.editComplaintId) {
+        return false
+      }
+
       const kk = String(state.dataPengusul.nomorKk || '').replace(/\D/g, '')
       if (!kk) {
         return false

--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -759,24 +759,25 @@ export default {
           RW: String(rw || ''),
         }
 
-        // TODO(BE): saat endpoint update siap, ganti menjadi:
-        // const isEdit = !!state.editComplaintId
-        // if (isEdit) {
-        //   return this.$gatewayPartnerAPI.put(`/aduan/complaints/${state.editComplaintId}`, payload, {
-        //     headers: state.authToken ? { Authorization: `Bearer ${state.authToken}` } : {},
-        //   })
-        // }
-        // Untuk sekarang tetap POST (create) walau mode edit.
-        const postComplaint = () =>
-          this.$gatewayPartnerAPI.post('/aduan/complaints', payload, {
-            headers: state.authToken
-              ? { Authorization: `Bearer ${state.authToken}` }
-              : {},
-          })
+        // Mode edit (US-013): PUT update ke endpoint /mobile
+        // Mode buat baru: POST create
+        const isEdit = !!state.editComplaintId
+        const headers = state.authToken
+          ? { Authorization: `Bearer ${state.authToken}` }
+          : {}
+
+        const sendComplaint = () =>
+          isEdit
+            ? this.$gatewayPartnerAPI.put(
+                `/aduan/complaints/${state.editComplaintId}/mobile`,
+                payload,
+                { headers }
+              )
+            : this.$gatewayPartnerAPI.post('/aduan/complaints', payload, { headers })
 
         let response
         try {
-          response = await postComplaint()
+          response = await sendComplaint()
         } catch (error) {
           if (isUnauthorizedError(error)) {
             commit('SET_STATUS_SUBMIT', 'SESSION_EXPIRED')


### PR DESCRIPTION
## FEAT
- **Tombol Tambah di Halaman List**: Menambahkan tombol "Tambah" pada halaman daftar usulan (`/imah-aing`) untuk navigasi cepat ke form pengajuan baru.
- **Prefill Lengkap dari Detail di Mode Edit**: Mengambil data detail usulan via GET `/aduan/complaints/{id}` dan mengisi seluruh field form (data pengusul, kondisi rumah, lokasi tanah, dokumen) secara lengkap.
- **Lock Field Identitas di Mode Edit**: Field NIK dan No KK pada StepTwo menjadi disabled ketika mode edit aktif (`isEditMode`) agar tidak dapat diubah.
- **Submit PUT untuk Edit Mode**: Mengganti endpoint submit dari POST (create) menjadi PUT `/aduan/complaints/{id}/mobile` saat mode edit.
- **Skip Cek Duplikat KK di Mode Edit**: Melewati pengecekan duplikat No KK jika sedang dalam mode edit untuk mencegah false positive.
- **Navigasi ke Form via `complaint_id`**: Mengubah parameter navigasi edit dari `item.id` menjadi `item.complaint_id` sesuai struktur response terkini.

## Related
-

## Overview
PR ini mengimplementasikan **Edit Usulan** pada modul **Imah Aing**. Terdapat 3 area perubahan utama:

1. **Halaman List (`/imah-aing/index.vue`)**: Menambahkan tombol "+ Tambah" untuk akses cepat ke form pengajuan baru, serta memperbaiki parameter navigasi edit menggunakan `complaint_id`.
2. **Halaman Form (`/imah-aing/form/index.vue`)**: Memperkenalkan method `setupEditOrFirstStep` yang menangani logika inisialisasi form, termasuk prefill lengkap dari data detail via `fetchComplaintDetail` + `hydrateFromDetail` sebagai overlay di atas baseline data list.
3. **Store (`store/imah-aing/imahAingForm.js`)**: Menambahkan getter `isEditMode`, action `fetchComplaintDetail` dan `hydrateFromDetail` untuk prefill, skip duplikat KK saat edit, serta mengubah logic submit dari POST ke PUT ketika mode edit aktif.

## Changes
- **Halaman List (`pages/imah-aing/index.vue`)**:
  - Tambah tombol "+ Tambah" dengan navigasi ke `goToForm()`.
  - Update method `editUsulan`: gunakan `item.complaint_id` sebagai parameter `edit` (fallback ke `item.id`).
- **Halaman Form (`pages/imah-aing/form/index.vue`)**:
  - Refaktor inisialisasi form ke method `setupEditOrFirstStep`.
  - Mode edit: set `editComplaintId` segera (sebelum `hydrateFromExisting`), lalu fetch detail via `fetchComplaintDetail`, overlay prefill via `hydrateFromDetail`; jika GET gagal, baseline data list tetap dipakai.
- **StepTwo (`components/ImahAing/Form/StepTwo.vue`)**:
  - Import `mapGetters` dari Vuex.
  - Tambahkan computed `...mapGetters('imahAingForm', ['isEditMode'])`.
  - Field NIK dan No KK ditambahkan binding `:disabled="isEditMode"`.
- **Store (`store/imah-aing/imahAingForm.js`)**:
  - Getter `isEditMode`: mengembalikan `true` jika `editComplaintId` terisi.
  - Action `fetchComplaintDetail`: GET `/aduan/complaints/{id}` dengan phase `verification`.
  - Action `hydrateFromDetail`: overlay prefill data pengusul (`user_name`, `user_nik`, `user_kk`, `user_phone`, `user_email`, dll), kondisi rumah (`description`, `complaint_subcategory_id`), lokasi tanah (`city_id`, `district_id`, `village_id`, `RT`, `RW`, `dusun_name`, `address_detail`, `address`, lokasi dari meta payload), dan dokumen (mapping `photos[].field` → slot store dengan status SUCCESS).
  - Action `checkKkDuplicate`: skip pengecekan jika `editComplaintId` aktif.
  - Action `submitForm`: ubah dari selalu POST menjadi PUT `/aduan/complaints/{id}/mobile` jika edit mode, POST jika baru.

## Preview
-

## Evidence
title: Implementasi Edit Usulan Imah Aing
project: Sapawarga
participants: @ekadhirapratama
screenshot: https://s.digitalservice.id/5UrKeT
