### PR TITLE
fix(imah-aing): handling input text & update endpoin API

### DIFF
--- a/components/ImahAing/Form/StepTwo.vue
+++ b/components/ImahAing/Form/StepTwo.vue
@@ -8,8 +8,17 @@
 
     <!-- Nama Calon Penerima Bantuan -->
     <ValidationProvider v-slot="{ errors }" class="flex flex-col gap-2 mb-5" rules="required" name="Nama Calon Penerima Bantuan (sesuai KTP)" vid="name">
-      <label>Nama Calon Penerima Bantuan (sesuai KTP) <span class="text-red-500">*</span></label>
-      <JdsInputText :value="setName" :error-message="errors[0]" @input="setName = $event" />
+      <BaseInputText
+        v-model="setName"
+        class="step-two-input-jds"
+        type="text"
+        label="Nama Calon Penerima Bantuan (sesuai KTP)"
+        required
+        :placeholder="zwsPlaceholder"
+        autocomplete="off"
+        :error="!!errors[0]"
+        :error-message="errors[0]"
+      />
     </ValidationProvider>
 
     <!-- No HP Calon Penerima Bantuan -->
@@ -28,9 +37,15 @@
     </ValidationProvider>
 
     <!-- Email Pribadi — OPSIONAL, EDITABLE -->
-    <ValidationProvider v-slot="{ errors }" class="flex flex-col gap-2 mb-5" rules="email" name="Email Pribadi Calon Penerima Bantuan" vid="email">
-      <label>Email Pribadi Calon Penerima Bantuan</label>
-      <JdsInputText :value="setEmail" :error-message="errors[0]" @input="setEmail = $event" />
+    <ValidationProvider class="flex flex-col gap-2 mb-5" rules="email" name="Email Pribadi Calon Penerima Bantuan" vid="email">
+      <BaseInputText
+        v-model="setEmail"
+        class="step-two-input-jds"
+        type="email"
+        label="Email Pribadi Calon Penerima Bantuan"
+        :placeholder="zwsPlaceholder"
+        autocomplete="off"
+      />
     </ValidationProvider>
 
     <!-- NIK Kepala Keluarga — WAJIB -->

--- a/plugins/gateway-partner-api.js
+++ b/plugins/gateway-partner-api.js
@@ -1,14 +1,23 @@
 import axios from 'axios'
 
 export default (context, inject) => {
+  const baseHeaders = {
+    common: {
+      'Api-Key': context.$config.apiKey,
+      'x-partner-id': context.$config.xPartnerId,
+    },
+  }
+
   const gatewayPartnerAPI = axios.create({
     baseURL: `${context.$config.baseURLGatewayPartner}/v1`,
-    headers: {
-      common: {
-        'Api-Key': context.$config.apiKey,
-        'x-partner-id': context.$config.xPartnerId,
-      },
-    },
+    headers: baseHeaders,
   })
+
+  const gatewayPartnerMainAPI = axios.create({
+    baseURL: `${context.$config.baseURLGatewayPartner}/main/v1`,
+    headers: baseHeaders,
+  })
+
   inject('gatewayPartnerAPI', gatewayPartnerAPI)
+  inject('gatewayPartnerMainAPI', gatewayPartnerMainAPI)
 }

--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -812,7 +812,7 @@ export default {
 
         const sendComplaint = () =>
           isEdit
-            ? this.$gatewayPartnerAPI.put(
+            ? this.$gatewayPartnerMainAPI.put(
                 `/aduan/complaints/${state.editComplaintId}/mobile`,
                 payload,
                 { headers }


### PR DESCRIPTION
## FEAT
- **Ganti JdsInputText dengan BaseInputText di StepTwo**: Field nama dan email pada `StepTwo` diganti dari `JdsInputText` ke `BaseInputText` agar konsisten dengan komponen lain dan mendukung atribut tambahan seperti `placeholder`, `autocomplete`, dan `required`.
- **Tambah `gatewayPartnerMainAPI` dan Pindahkan API Update Keluhan**: Menambahkan instance axios baru `gatewayPartnerMainAPI` dengan base URL `/main/v1`, dan memindahkan pemanggilan API update keluhan (`PUT /aduan/complaints/.../mobile`) untuk menggunakan instance tersebut.

## Related
-

## Overview
PR ini berisi dua perbaikan lanjutan pada modul **Imah Aing**:

1. **Penggantian komponen input di StepTwo**: Field nama (`setName`) dan email (`setEmail`) sebelumnya menggunakan `JdsInputText` yang tidak mendukung atribut seperti `placeholder` dan `autocomplete`. Diganti ke `BaseInputText` dengan v-model, serta menggunakan `zwsPlaceholder` sebagai nilai placeholder dan `autocomplete="off"` untuk mencegah autofill browser.

2. **Refactor API untuk update keluhan**: API update keluhan (`PUT /aduan/complaints/:id/mobile`) sebelumnya memanggil `gatewayPartnerAPI` yang berbase URL `/v1`, padahal endpoint tersebut berada di `/main/v1`. Ditambahkan instance baru `gatewayPartnerMainAPI` di plugin `gateway-partner-api.js` dengan base URL yang tepat, dan store diperbarui untuk menggunakannya.

## Changes
- **Komponen StepTwo (`components/ImahAing/Form/StepTwo.vue`)**:
  - Ganti `JdsInputText` → `BaseInputText` untuk field `setName` dan `setEmail`.
  - Tambahkan atribut `class`, `type`, `label`, `required`, `placeholder`, `autocomplete`, `error`, dan `error-message` sesuai interface `BaseInputText`.
  - Hilangkan `v-slot="{ errors }"` dari `ValidationProvider` email (tidak diperlukan karena error tidak ditampilkan eksplisit di field tersebut).
- **Plugin Gateway (`plugins/gateway-partner-api.js`)**:
  - Ekstrak `baseHeaders` ke variabel bersama agar tidak duplikasi antara `gatewayPartnerAPI` dan `gatewayPartnerMainAPI`.
  - Tambahkan instance `gatewayPartnerMainAPI` dengan `baseURL: .../main/v1`.
  - Inject `gatewayPartnerMainAPI` ke context Nuxt.
- **Store (`store/imah-aing/imahAingForm.js`)**:
  - Ganti `this.$gatewayPartnerAPI.put(...)` → `this.$gatewayPartnerMainAPI.put(...)` pada action update keluhan.

## Preview
-

## Evidence
title: Perbaikan Imah Aing — Ganti JdsInputText ke BaseInputText di StepTwo dan Update Endpoin API
project: Sapawarga
participants: @ekadhirapratama
screenshot: https://s.digitalservice.id/Wezr3g
