### PR TITLE
fix(imah-aing): guard fetchHistory when id and kk are empty

### DIFF
--- a/store/imah-aing/imahAingHistory.js
+++ b/store/imah-aing/imahAingHistory.js
@@ -101,6 +101,12 @@ export const actions = {
     const { metaPayload, pagination } = state
     const { id, role, kk } = metaPayload
 
+    if (!id && !kk) {
+      commit('SET_ITEMS', [])
+      commit('SET_STATUS', 'SUCCESS')
+      return
+    }
+
     const roleLower = (role || '').trim().toLowerCase()
     const params = {
       limit: pagination.limit,


### PR DESCRIPTION
## FEAT
- **Guard `fetchHistory` saat `id` dan `kk` kosong**: Menambahkan pengecekan di awal action `fetchHistory` — jika `id` dan `kk` dari `metaPayload` keduanya kosong, action langsung mengembalikan state `SUCCESS` dengan items kosong tanpa memanggil API, sehingga di page akan men-trigger redirect ke form.

## Related
-

## Overview
Sebelum fix ini, ketika `metaPayload` tidak memiliki `id` dan `kk` (keduanya string kosong dari default state), `fetchHistory` tetap menembak API dengan parameter kosong. Hal ini menyebabkan API mengembalikan seluruh data tanpa filter.

Fix ini menambahkan early return di `fetchHistory`:

```js
if (!id && !kk) {
  commit('SET_ITEMS', [])
  commit('SET_STATUS', 'SUCCESS')
  return
}
```

Dengan ini, yang sudah ada di `mounted()` (`status === 'SUCCESS' && items.length === 0`) akan menangkap kondisi ini dan me-redirect user ke halaman form — konsisten dengan pola guard yang sudah diimplementasikan sebelumnya.

## Changes
- **Store (`store/imah-aing/imahAingHistory.js`)**:
  - Tambah early return di `fetchHistory` sebelum params dibangun: jika `id` dan `kk` keduanya falsy, commit `SET_ITEMS([])` dan `SET_STATUS('SUCCESS')` lalu return — mencegah API call dengan blank params yang mengekspos semua data.

## Preview
-

## Evidence
title: Guard fetchHistory saat id dan kk kosong pada Riwayat Ajuan
project: Sapawarga
participants: @ekadhirapratama
screenshot: https://s.digitalservice.id/q4naBd