### PR TITLE
fix(imah-aing): hide tambah button for warga role on history page

### DIFF
--- a/pages/imah-aing/index.vue
+++ b/pages/imah-aing/index.vue
@@ -15,7 +15,7 @@
         <div class="px-4 py-4 md:px-7 md:py-5">
           <!-- Add new submission -->
           <div class="flex justify-end mb-4">
-            <Button variant="primary" @click="goToForm">
+            <Button v-if="!isWarga" variant="primary" @click="goToForm">
               + Tambah
             </Button>
           </div>
@@ -103,7 +103,7 @@ export default {
     }
   },
   computed: {
-    ...mapState('imahAingHistory', ['items', 'selectedIds', 'pagination', 'status', 'errorMessage', 'authToken']),
+    ...mapState('imahAingHistory', ['items', 'selectedIds', 'pagination', 'status', 'errorMessage', 'authToken', 'metaPayload']),
     isLoading() {
       return this.status === 'LOADING' && this.pagination.page === 1
     },
@@ -115,6 +115,9 @@ export default {
     },
     useMock() {
       return this.$route.query.use_mock === 'true'
+    },
+    isWarga() {
+      return (this.metaPayload?.role || '').trim().toLowerCase() === 'warga'
     }
   },
   created() {


### PR DESCRIPTION
## FEAT
- **Sembunyikan tombol "+ Tambah" untuk role warga**: Tombol tambah di halaman Riwayat Ajuan kini disembunyikan (`v-if`) ketika role pengguna adalah `warga`, sehingga warga tidak bisa membuat pengajuan baru dari halaman riwayat.

## Related
-

## Overview
PR ini menyembunyikan tombol "+ Tambah" di halaman Riwayat Ajuan (`pages/imah-aing/index.vue`) ketika role pengguna adalah `warga`:

1. **Expose `metaPayload` dari store**: Tambah `metaPayload` ke `mapState` dari `imahAingHistory` store — state ini sudah di-commit di `created()` via `SET_META_PAYLOAD` saat decode query param `meta`.

2. **Computed `isWarga`**: Membaca `metaPayload.role`, trim dan lowercase, lalu membandingkan dengan `'warga'`. Jika `role` kosong/null (mis. mock mode), `isWarga` = `false` → tombol tetap tampil (perilaku aman).

3. **Kondisional tombol Tambah**: Tombol `+ Tambah` diberi `v-if="!isWarga"` sehingga tersembunyi sepenuhnya untuk role `warga`. Role lain (`rw`, `rt`, dsb.) tidak terdampak.

## Changes
- **Page (`pages/imah-aing/index.vue`)**:
  - Tambah `metaPayload` ke `mapState('imahAingHistory', [...])`
  - Tambah computed `isWarga()` yang mengecek `metaPayload.role === 'warga'`
  - Tambah `v-if="!isWarga"` pada tombol `+ Tambah`

## Preview
-

## Evidence
title: Sembunyikan Tombol Tambah untuk Role Warga di Halaman Riwayat Ajuan
project: Sapawarga
participants: @ekadhirapratama
screenshot: https://s.digitalservice.id/3dXf2B