### PR TITLE
feat(imah-aing): add proposer metadata and conditional access to history page

### DIFF
--- a/components/ImahAing/History/ListItem.vue
+++ b/components/ImahAing/History/ListItem.vue
@@ -37,14 +37,14 @@
       </div>
     </div>
 
-    <!-- Kolom Kanan: Tanggal (atas) + Tombol Edit (bawah, hanya unverified) -->
+    <!-- Kolom Kanan: Tanggal (atas) + Tombol Edit (bawah) -->
     <!-- justify-center saat tidak ada tombol Edit agar tanggal center vertikal -->
     <div
       class="flex flex-col flex-shrink-0 items-end gap-2 self-stretch"
-      :class="{ 'justify-center': !isUnverified }"
+      :class="{ 'justify-center': !canEdit }"
     >
       <button
-        v-if="isUnverified"
+        v-if="canEdit"
         class="px-3 py-1.5 text-xs font-medium text-[#069550] bg-[#069550]/10 rounded-md hover:bg-[#069550]/20 transition-colors"
         @click.stop="$emit('edit')"
       >
@@ -71,10 +71,14 @@ export default {
     selected: {
       type: Boolean,
       default: false
+    },
+    canEdit: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {
-    /** Kunci status — satu sumber untuk isVerified, isUnverified, dan statusStyle */
+    /** Kunci status — satu sumber untuk isVerified dan statusStyle */
     statusKey() {
       return this.item.complaint_status?.id
         || this.item.complaint_status_id
@@ -84,9 +88,6 @@ export default {
     },
     isVerified() {
       return this.statusKey === 'verified'
-    },
-    isUnverified() {
-      return this.statusKey === 'unverified'
     },
     /** Objek style guide (name + hex) dari mapping 13 status */
     statusStyle() {

--- a/pages/imah-aing/index.vue
+++ b/pages/imah-aing/index.vue
@@ -33,6 +33,7 @@
               :key="item.id"
               :item="item"
               :selected="selectedIds.includes(item.id)"
+              :can-edit="canEdit(item)"
               @toggle="toggleSelect(item.id)"
               @click="openPreview(item)"
               @edit="editUsulan(item)"
@@ -204,6 +205,15 @@ export default {
         path: '/imah-aing/form',
         query: this.$route.query,
       })
+    },
+
+    canEdit(item) {
+      const EDITABLE_STATUSES = ['unverified', 'rejected', 'rejected_appeal', 'rejected_criteria']
+      const statusId = item.complaint_status?.id || item.complaint_status_id || ''
+      const isSelfProposer =
+        item.user_id === this.metaPayload.id ||
+        (this.isWarga && item.user_kk === this.metaPayload.kk)
+      return isSelfProposer && EDITABLE_STATUSES.includes(statusId)
     },
 
     editUsulan(item) {

--- a/store/imah-aing/imahAingHistory.js
+++ b/store/imah-aing/imahAingHistory.js
@@ -102,7 +102,7 @@ export const actions = {
 
   async fetchHistory({ commit, state }) {
     const { metaPayload, pagination } = state
-    const { id, role, kk } = metaPayload
+    const { id, role, kk, rt, rw, village_id: villageId } = metaPayload
 
     if (!id && !kk) {
       commit('SET_ITEMS', [])
@@ -119,10 +119,24 @@ export const actions = {
       current_user_id: id,
     }
 
-    if (roleLower && roleLower !== 'warga') {
-      params.user_id = id
-    } else {
-      params.user_kk = kk
+    switch (roleLower) {
+      case 'warga':
+        params.user_kk = kk
+        break
+      case 'rt':
+        params.rt = rt // TODO(BE): konfirmasi nama param — rt atau user_rt
+        break
+      case 'rw':
+        params.rw = rw // TODO(BE): konfirmasi nama param — rw atau user_rw
+        break
+      case 'kades':
+      case 'lurah':
+        params.village_id = villageId
+        break
+      default:
+        commit('SET_ITEMS', [])
+        commit('SET_STATUS', 'SUCCESS')
+        return
     }
 
     commit('SET_STATUS', 'LOADING')

--- a/store/imah-aing/imahAingHistory.js
+++ b/store/imah-aing/imahAingHistory.js
@@ -11,6 +11,9 @@ const getDefaultState = () => ({
     id: '',
     role: '',
     token: '',
+    rt: '',         // diisi jika role === 'rt' (format string, mis. "003")
+    rw: '',         // diisi jika role === 'rw'
+    village_id: '', // diisi jika role === 'kades' atau 'lurah'
   },
 
   /** Daftar complaint / usulan */


### PR DESCRIPTION
## FEAT

- **Metadata Pengusul**: Tambah field `rt`, `rw`, `village_id` ke state `metaPayload`; refactor `fetchHistory` dengan `switch` per role untuk filter area kewenangan masing-masing
- **Kondisional Tombol Edit**: Tombol Edit hanya tampil untuk pengusul item itu sendiri dengan status yang dapat diedit (`unverified`, `rejected`, `rejected_appeal`, `rejected_criteria`)
- **Kondisional Tombol Tambah**: Tombol Tambah disembunyikan untuk role `warga`

## Related

-

## Overview

PR ini mengimplementasikan dua fitur lanjutan modul Imah Aing: penambahan metadata pengusul dan kondisional akses halaman riwayat berdasarkan role.

1. **Metadata Pengusul**: Tiga field baru (`rt`, `rw`, `village_id`) ditambahkan ke state `metaPayload`. Field-field ini di-decode otomatis dari meta deeplink via mutation `SET_META_PAYLOAD` yang sudah menggunakan spread. Di `fetchHistory`, logika `if/else` biner diganti dengan `switch` per role — setiap role menggunakan param area yang sesuai sebagai filter query API.
2. **Kondisional Tombol Edit**: Method `canEdit(item)` di halaman riwayat mengecek dua kondisi: viewer adalah pengusul item tersebut (`item.user_id === metaPayload.id`) dan status item termasuk dalam daftar status yang dapat diedit. Hasilnya diteruskan sebagai prop `:can-edit` ke `ListItem`.
3. **Kondisional Tombol Tambah**: Tombol Tambah disembunyikan untuk role `warga` karena warga hanya boleh melihat dan mengedit usulan yang sudah ada, bukan membuat dari halaman riwayat.

## Changes

- **`ImahAingHistory` Store (`store/imah-aing/imahAingHistory.js`)**:
  - Tambah `rt`, `rw`, `village_id` ke `metaPayload` di `getDefaultState()` (default string kosong)
  - Refactor `fetchHistory`: destructure field baru; ganti `if/else` dengan `switch` per role
  - Role `warga` → `user_kk`; `rt` → `rt`; `rw` → `rw`; `kades`/`lurah` → `village_id`; role lain → return list kosong
  - ⚠️ `TODO(BE)`: nama param untuk RT dan RW (`rt`/`rw` vs `user_rt`/`user_rw`) masih menunggu konfirmasi backend
- **`ImahAingHistoryListItem` (`components/ImahAing/History/ListItem.vue`)**:
  - Tambah prop `canEdit: Boolean` (default `false`)
  - Ganti `v-if="isUnverified"` → `v-if="canEdit"` pada tombol Edit Ajuan
  - Hapus computed `isUnverified` (tidak lagi dibutuhkan di template)
- **Halaman Riwayat (`pages/imah-aing/index.vue`)**:
  - Tambah `metaPayload` ke `mapState`
  - Tambah computed `isWarga` — cek role dari `metaPayload`
  - Tambah method `canEdit(item)` — validasi kepemilikan item dan status editable
  - Teruskan `:can-edit="canEdit(item)"` ke `ImahAingHistoryListItem`
  - Tambah `v-if="!isWarga"` pada tombol Tambah

## Preview

-

## Evidence
title: feat(imah-aing): conditionally show edit button based on ownership and status (A2)
project: Sapawarga
participants: @ekadhirapratama
screenshot: