### PR TITLE
feat(imah-aing): edit status condition, name masking, and history format

### DIFF
--- a/components/ImahAing/History/ListItem.vue
+++ b/components/ImahAing/History/ListItem.vue
@@ -41,19 +41,32 @@
       </div>
     </div>
 
-    <!-- Kolom Kanan: Tanggal (atas) + Tombol Edit (bawah) -->
-    <!-- justify-center saat tidak ada tombol Edit agar tanggal center vertikal -->
+    <!-- Kolom Kanan: Tanggal (atas) + Tombol Edit + Info Icon (bawah) -->
     <div
       class="flex flex-col flex-shrink-0 items-end gap-2 self-stretch"
       :class="{ 'justify-center': !canEdit }"
     >
-      <button
-        v-if="canEdit"
-        class="px-3 py-1.5 text-xs font-medium text-[#069550] bg-[#069550]/10 rounded-md hover:bg-[#069550]/20 transition-colors"
-        @click.stop="$emit('edit')"
-      >
-        Edit Ajuan
-      </button>
+      <div class="flex items-center gap-1">
+        <button
+          v-if="canEdit"
+          class="px-3 py-1.5 text-xs font-medium text-[#069550] bg-[#069550]/10 rounded-md hover:bg-[#069550]/20 transition-colors"
+          @click.stop="$emit('edit')"
+        >
+          Edit Ajuan
+        </button>
+        <button
+          type="button"
+          class="w-5 h-5 flex items-center justify-center rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors flex-shrink-0"
+          :title="editTooltipText"
+          @click.stop
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10"/>
+            <line x1="12" y1="8" x2="12" y2="12"/>
+            <line x1="12" y1="16" x2="12.01" y2="16"/>
+          </svg>
+        </button>
+      </div>
       <span class="text-xs text-gray-400 whitespace-nowrap">
         {{ formattedDate }}
       </span>
@@ -129,6 +142,9 @@ export default {
       }
       const key = (this.proposerRole || '').trim().toLowerCase()
       return ROLE_LABELS[key] || ''
+    },
+    editTooltipText() {
+      return 'Usulan hanya dapat di-update oleh Pengusul. Proses Update hanya berlaku selama Usulan masih dalam status Menunggu Verifikasi atau Tahap Verifikasi'
     }
   },
   methods: {

--- a/components/ImahAing/History/ListItem.vue
+++ b/components/ImahAing/History/ListItem.vue
@@ -27,6 +27,10 @@
       <div class="text-sm font-semibold text-gray-900 mt-0.5 dark:text-dark-emphasis-high">
         {{ displayName }}
       </div>
+      <!-- TODO(BE): proposer_role field needed from list complaints endpoint for non-self items -->
+      <div v-if="proposerRoleLabel" class="text-xs text-gray-400 mt-0.5">
+        Pengusul: {{ proposerRoleLabel }}
+      </div>
       <div class="mt-1">
         <span
           class="inline-flex items-center text-xs font-medium px-2 py-0.5 rounded"
@@ -79,6 +83,10 @@ export default {
     isSelfItem: {
       type: Boolean,
       default: true
+    },
+    proposerRole: {
+      type: String,
+      default: ''
     }
   },
   computed: {
@@ -109,6 +117,18 @@ export default {
       const raw = this.item.user_name || this.item.name || ''
       if (!raw) return '-'
       return this.isSelfItem ? raw : this.maskName(raw)
+    },
+    proposerRoleLabel() {
+      const ROLE_LABELS = {
+        warga: 'Warga',
+        rt: 'Ketua RT',
+        rw: 'Ketua RW',
+        kadus: 'Kepala Dusun',
+        kades: 'Kepala Desa',
+        lurah: 'Lurah',
+      }
+      const key = (this.proposerRole || '').trim().toLowerCase()
+      return ROLE_LABELS[key] || ''
     }
   },
   methods: {

--- a/components/ImahAing/History/ListItem.vue
+++ b/components/ImahAing/History/ListItem.vue
@@ -25,7 +25,7 @@
         IA-{{ item.user_nik || item.nik || '-' }}
       </div>
       <div class="text-sm font-semibold text-gray-900 mt-0.5 dark:text-dark-emphasis-high">
-        {{ item.user_name || item.name || '-' }}
+        {{ displayName }}
       </div>
       <div class="mt-1">
         <span
@@ -75,6 +75,10 @@ export default {
     canEdit: {
       type: Boolean,
       default: false
+    },
+    isSelfItem: {
+      type: Boolean,
+      default: true
     }
   },
   computed: {
@@ -100,6 +104,22 @@ export default {
     formattedDate() {
       const date = this.item.created_at || this.item.submitted_at
       return formatDate(date, 'dd MMM yyyy')
+    },
+    displayName() {
+      const raw = this.item.user_name || this.item.name || ''
+      if (!raw) return '-'
+      return this.isSelfItem ? raw : this.maskName(raw)
+    }
+  },
+  methods: {
+    maskName(fullName) {
+      return fullName
+        .split(' ')
+        .map((word) => {
+          if (word.length <= 2) return word.toUpperCase()
+          return word.substring(0, 2).toUpperCase() + '*'.repeat(Math.min(word.length - 2, 6))
+        })
+        .join(' ')
     }
   }
 }

--- a/pages/imah-aing/index.vue
+++ b/pages/imah-aing/index.vue
@@ -35,6 +35,7 @@
               :selected="selectedIds.includes(item.id)"
               :can-edit="canEdit(item)"
               :is-self-item="isSelfItem(item)"
+              :proposer-role="isSelfItem(item) ? (metaPayload.role || '') : (item.proposer_role || '')"
               @toggle="toggleSelect(item.id)"
               @click="openPreview(item)"
               @edit="editUsulan(item)"

--- a/pages/imah-aing/index.vue
+++ b/pages/imah-aing/index.vue
@@ -34,6 +34,7 @@
               :item="item"
               :selected="selectedIds.includes(item.id)"
               :can-edit="canEdit(item)"
+              :is-self-item="isSelfItem(item)"
               @toggle="toggleSelect(item.id)"
               @click="openPreview(item)"
               @edit="editUsulan(item)"
@@ -207,13 +208,18 @@ export default {
       })
     },
 
+    isSelfItem(item) {
+      if (!item) return false
+      const { id, kk } = this.metaPayload || {}
+      if (item.user_id && id && item.user_id === id) return true
+      if (this.isWarga && item.user_kk && kk && item.user_kk === kk) return true
+      return false
+    },
+
     canEdit(item) {
       const EDITABLE_STATUSES = ['unverified', 'rejected_appeal']
       const statusId = item.complaint_status?.id || item.complaint_status_id || ''
-      const isSelfProposer =
-        item.user_id === this.metaPayload.id ||
-        (this.isWarga && item.user_kk === this.metaPayload.kk)
-      return isSelfProposer && EDITABLE_STATUSES.includes(statusId)
+      return this.isSelfItem(item) && EDITABLE_STATUSES.includes(statusId)
     },
 
     editUsulan(item) {

--- a/pages/imah-aing/index.vue
+++ b/pages/imah-aing/index.vue
@@ -208,7 +208,7 @@ export default {
     },
 
     canEdit(item) {
-      const EDITABLE_STATUSES = ['unverified', 'rejected', 'rejected_appeal', 'rejected_criteria']
+      const EDITABLE_STATUSES = ['unverified', 'rejected_appeal']
       const statusId = item.complaint_status?.id || item.complaint_status_id || ''
       const isSelfProposer =
         item.user_id === this.metaPayload.id ||


### PR DESCRIPTION
## FEAT

- **Kondisi Status Edit (E1)**: Batasi `EDITABLE_STATUSES` hanya `unverified` dan `rejected_appeal` — hapus `rejected` dan `rejected_criteria`
- **Masking Nama Pengusul (E2)**: Nama pengusul di-mask jika item bukan milik viewer (2 karakter pertama + `*` maks 6 per kata)
- **Label Role Pengusul (E3a)**: Tambah baris "Pengusul: [role]" di bawah nama pada setiap list item
- **Tooltip Tombol Edit (E3b)**: Tambah info icon dengan tooltip aturan edit yang selalu tampil di area kanan list item

## Related

- [Backlog row60, row62, row63](https://docs.google.com/spreadsheets/d/1APrma05qnRBqLbfAkUyl4FScL7lPJ2oGiGZYXUnkkc0/edit?gid=2069695550#gid=2069695550)

## Overview

Tiga penyempurnaan lanjutan modul Imah Aing — kondisi edit, masking nama, dan format tampilan riwayat.

1. **EDITABLE_STATUSES (E1)**: Status `rejected` dan `rejected_criteria` dihapus karena tidak ada masa sanggah; hanya `unverified` (belum diverifikasi) dan `rejected_appeal` (dalam masa sanggah) yang diizinkan edit.
2. **Masking nama (E2)**: Method `isSelfItem()` ditambah di `index.vue` untuk menentukan kepemilikan item. Prop `isSelfItem` diteruskan ke `ListItem.vue` — nama ditampilkan asli jika milik viewer, di-mask jika bukan (contoh: "Imam Fadhillah" → "IM** FA******").
3. **Label role + tooltip (E3a/E3b)**: Prop `proposerRole` diteruskan ke `ListItem.vue` untuk menampilkan label "Pengusul: Ketua RT" dst. Info icon ℹ dengan native tooltip aturan edit selalu tampil di samping tombol Edit Ajuan.

## Changes

- **`ImahAingHistoryListItem` (`components/ImahAing/History/ListItem.vue`)**:
  - Tambah props: `isSelfItem` (Boolean, default `true`), `proposerRole` (String, default `''`)
  - Tambah computed: `displayName` (dengan masking), `proposerRoleLabel` (mapping role ke label Indonesia), `editTooltipText`
  - Tambah method: `maskName(fullName)` — masking 2 karakter pertama + `*` maks 6 per kata
  - Update template: nama pakai `displayName`, baris "Pengusul:" dengan `v-if`, info icon dengan `:title` tooltip di kolom kanan
- **`pages/imah-aing/index.vue`**:
  - Update `EDITABLE_STATUSES` — hapus `rejected` dan `rejected_criteria`
  - Tambah method `isSelfItem()` — cek kepemilikan item berdasarkan `user_id` dan `user_kk`
  - Refactor `canEdit()` — gunakan `isSelfItem()` (tidak duplikasi logika)
  - Teruskan props `:is-self-item` dan `:proposer-role` ke `<ImahAingHistoryListItem>`

## Preview

- Tampilan target: `IA-{NIK} | [Edit Ajuan] [ℹ]` / `IM** FA****** | [tanggal]` / `Pengusul: Ketua RT` / `[Badge Status]`
- Info icon selalu tampil; hover menampilkan tooltip teks aturan edit
- TODO(BE): field `proposer_role` di response list complaints masih awaited — untuk sementara label tampil hanya untuk item milik viewer sendiri

## Evidence
title: feat(imah-aing): add info icon with edit tooltip next to edit button in list item
project: Sapawarga
participants: @ekadhirapratama
screenshot: https://s.digitalservice.id/9yo7Ko