### PR TITLE
feat(imah-aing): UX fixes — info icon snackbar, disable NIK/KK for warga, redirect Tutup to history

### DIFF
--- a/components/ImahAing/Form/StepTwo.vue
+++ b/components/ImahAing/Form/StepTwo.vue
@@ -62,7 +62,7 @@
         type="text"
         label="NIK Calon Penerima Bantuan"
         required
-        :disabled="isEditMode"
+        :disabled="isEditMode || isNikKkLocked"
         :maxlength="maxNikKkLength"
         :placeholder="zwsPlaceholder"
         autocomplete="off"
@@ -85,7 +85,7 @@
         type="text"
         label="No KK Calon Penerima Bantuan"
         required
-        :disabled="isEditMode"
+        :disabled="isEditMode || isNikKkLocked"
         :maxlength="maxNikKkLength"
         :placeholder="zwsPlaceholder"
         autocomplete="off"
@@ -134,6 +134,14 @@ export default {
   },
   computed: {
     ...mapGetters('imahAingForm', ['isEditMode']),
+    isSapawargaSource() {
+      return this.$store.state.imahAingForm.sourceId === 'sapawarga'
+    },
+    isNikKkLocked() {
+      if (this.isEditMode) return false
+      const role = (this.$store.state.imahAingForm.dataPengusul.role || '').trim().toLowerCase()
+      return this.isSapawargaSource && role === 'warga'
+    },
     name() {
       return this.$store.state.imahAingForm.dataPengusul.name
     },

--- a/components/ImahAing/History/ListItem.vue
+++ b/components/ImahAing/History/ListItem.vue
@@ -58,7 +58,7 @@
           type="button"
           class="w-5 h-5 flex items-center justify-center rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors flex-shrink-0"
           :title="editTooltipText"
-          @click.stop
+          @click.stop="$emit('show-info')"
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="10"/>

--- a/pages/imah-aing/form/index.vue
+++ b/pages/imah-aing/form/index.vue
@@ -132,7 +132,7 @@
       name-icon="check-mark-circle"
       size="16px"
       :description="successDescription"
-      @close="backToFormPage"
+      @close="handleCloseAfterSuccess"
       @click="backToFormPage"
     />
 
@@ -367,6 +367,17 @@ export default {
       setTimeout(() => {
         this.isLoading = false
       }, 1500)
+    },
+    handleCloseAfterSuccess() {
+      const { id, nomorKk } = this.$store.state.imahAingForm.dataPengusul || {}
+      if (id || nomorKk) {
+        this.$router.push({
+          path: '/imah-aing',
+          query: this.$route.query,
+        })
+      } else {
+        this.backToFormPage()
+      }
     },
     handleSessionExpired() {
       if (process.client) {

--- a/pages/imah-aing/index.vue
+++ b/pages/imah-aing/index.vue
@@ -39,6 +39,7 @@
               @toggle="toggleSelect(item.id)"
               @click="openPreview(item)"
               @edit="editUsulan(item)"
+              @show-info="showEditInfo"
             />
 
             <!-- Load more -->
@@ -78,6 +79,14 @@
       @close="previewOpen = false"
     />
 
+    <!-- Info snackbar for edit restriction -->
+    <div
+      v-if="showInfoSnackbar"
+      class="fixed bottom-20 left-4 right-4 z-20 md:max-w-[650px] md:mx-auto md:left-1/2 md:-translate-x-1/2 md:right-auto md:w-[calc(650px-2rem)] bg-gray-700 text-white text-sm rounded-lg px-4 py-3 shadow-lg"
+    >
+      Usulan hanya dapat di-update oleh Pengusul. Proses Update hanya berlaku selama Usulan masih dalam status Menunggu Verifikasi atau Tahap Verifikasi.
+    </div>
+
     <!-- Cancel Confirmation Dialog -->
     <BaseDialog
       :show-popup="showCancelDialog"
@@ -102,7 +111,8 @@ export default {
     return {
       previewOpen: false,
       previewItem: null,
-      showCancelDialog: false
+      showCancelDialog: false,
+      showInfoSnackbar: false
     }
   },
   computed: {
@@ -231,6 +241,11 @@ export default {
           edit: item.id,
         },
       })
+    },
+
+    showEditInfo() {
+      this.showInfoSnackbar = true
+      setTimeout(() => { this.showInfoSnackbar = false }, 4000)
     },
 
     async handleCancel() {


### PR DESCRIPTION
## FEAT

- **Disable NIK & KK untuk role warga dari Sapawarga**: field NIK dan KK di-lock saat warga mengakses dari Sapawarga karena data sudah prefill dari meta — warga tidak dapat mengusulkan orang lain
- **Redirect tombol Tutup ke halaman riwayat**: setelah submit berhasil, tombol Tutup mengarahkan ke `/imah-aing` jika meta mengandung `user_id` atau `kk`
- **Info icon clickable dengan snackbar tooltip**: ikon info di list item riwayat kini bisa diklik dan memunculkan snackbar dismissible yang menjelaskan keterbatasan edit usulan

## Related

-

## Overview
PR ini mencakup tiga perbaikan UX pada modul Imah Aing yang berkaitan dengan alur dari Sapawarga deeplink.

1. **Restrict NIK & KK untuk warga**: Saat `sourceId === 'sapawarga'` dan role adalah `warga`, computed `isNikKkLocked` mengembalikan `true` sehingga field NIK dan KK di-disable. Role lain (RT, RW, kades, lurah) tetap bisa menginput NIK/KK warga yang diusulkan.
2. **Redirect Tutup ke riwayat**: Method `handleCloseAfterSuccess` menggantikan `backToFormPage` pada handler `@close` modal SUCCESS. Jika `dataPengusul.id` atau `nomorKk` tersedia, user diarahkan ke `/imah-aing` dengan query yang sama; jika tidak, fallback ke reset form.
3. **Info icon snackbar**: Ikon info di `ListItem.vue` kini emit event `show-info` yang ditangkap parent (`index.vue`) untuk menampilkan snackbar 4 detik dengan pesan keterbatasan edit.

## Changes

- **`ImahAingFormStepTwo` (`components/ImahAing/Form/StepTwo.vue`)**:
  - Tambah computed `isSapawargaSource` dan `isNikKkLocked`
  - Update `:disabled` field NIK dan KK menjadi `isEditMode || isNikKkLocked`

- **`pages/imah-aing/form/index.vue`**:
  - Tambah method `handleCloseAfterSuccess` dengan logika redirect ke riwayat
  - Update `@close` pada modal SUCCESS dari `backToFormPage` ke `handleCloseAfterSuccess`

- **`ImahAingHistoryListItem` (`components/ImahAing/History/ListItem.vue`)**:
  - Update `@click.stop` pada info icon menjadi `@click.stop="$emit('show-info')"`

- **`pages/imah-aing/index.vue`**:
  - Tambah handler `@show-info="showEditInfo"` pada `ImahAingHistoryListItem`
  - Tambah snackbar fixed-bottom dengan pesan keterbatasan edit
  - Tambah method `showEditInfo` dan state `showInfoSnackbar`

## Preview

-

## Evidence
title: feat(imah-aing): redirect close button to history page after successful submit
project: Sapawarga
participants: @ekadhirapratama
screenshot: https://s.digitalservice.id/leme5U