### PR TITLE
fix(imah-aing): history non-warga dynamic params & preview masking fix

### DIFF
--- a/components/ImahAing/History/PreviewModal.vue
+++ b/components/ImahAing/History/PreviewModal.vue
@@ -33,19 +33,19 @@
             <div class="space-y-1">
               <span class="text-xs text-gray-500 uppercase font-bold">NIK</span>
               <p class="text-sm font-medium text-gray-900 dark:text-dark-emphasis-high">
-                {{ resolvedItem?.user_nik || resolvedItem?.nik || '-' }}
+                {{ displayNik }}
               </p>
             </div>
             <div class="space-y-1">
               <span class="text-xs text-gray-500 uppercase font-bold">KK</span>
               <p class="text-sm font-medium text-gray-900 dark:text-dark-emphasis-high">
-                {{ resolvedItem?.user_kk || resolvedItem?.kk || '-' }}
+                {{ displayKk }}
               </p>
             </div>
             <div class="space-y-1">
               <span class="text-xs text-gray-500 uppercase font-bold">Nama</span>
               <p class="text-sm font-medium text-gray-900 dark:text-dark-emphasis-high">
-                {{ resolvedItem?.user_name || resolvedItem?.name || '-' }}
+                {{ displayName }}
               </p>
             </div>
             <div class="space-y-1">
@@ -130,6 +130,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    isSelfItem: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {
@@ -141,7 +145,23 @@ export default {
     resolvedItem() {
       return this.detail || this.item
     },
+    displayName() {
+      const raw = this.item?.user_name || this.item?.name || ''
+      if (!raw) return '-'
+      return this.isSelfItem ? raw : this.maskName(raw)
+    },
+    displayNik() {
+      const raw = this.item?.user_nik || this.item?.nik || ''
+      if (!raw) return '-'
+      return this.isSelfItem ? raw : this.maskNumber(raw)
+    },
+    displayKk() {
+      const raw = this.item?.user_kk || this.item?.kk || ''
+      if (!raw) return '-'
+      return this.isSelfItem ? raw : this.maskNumber(raw)
+    },
     photos() {
+      if (!this.isSelfItem) return []
       const photos = this.resolvedItem?.photos || this.resolvedItem?.images || []
       return Array.isArray(photos) ? photos : []
     },
@@ -201,6 +221,19 @@ export default {
     },
   },
   methods: {
+    maskName(fullName) {
+      return fullName
+        .split(' ')
+        .map((word) => {
+          if (word.length <= 2) return word.toUpperCase()
+          return word.substring(0, 2).toUpperCase() + '*'.repeat(Math.min(word.length - 2, 6))
+        })
+        .join(' ')
+    },
+    maskNumber(value) {
+      if (value.length <= 8) return value
+      return value.substring(0, 4) + '********' + value.slice(-4)
+    },
     async loadDetail() {
       this.detailLoading = true
       try {

--- a/store/imah-aing/imahAingHistory.js
+++ b/store/imah-aing/imahAingHistory.js
@@ -131,24 +131,12 @@ export const actions = {
       current_user_id: id,
     }
 
-    switch (roleLower) {
-      case 'warga':
-        params.user_kk = kk
-        break
-      case 'rt':
-        params.rt = rt // TODO(BE): konfirmasi nama param — rt atau user_rt
-        break
-      case 'rw':
-        params.rw = rw // TODO(BE): konfirmasi nama param — rw atau user_rw
-        break
-      case 'kades':
-      case 'lurah':
-        params.village_id = villageId
-        break
-      default:
-        commit('SET_ITEMS', [])
-        commit('SET_STATUS', 'SUCCESS')
-        return
+    if (roleLower === 'warga') {
+      params.user_kk = kk
+    } else {
+      if (rt)        params.rt = rt
+      if (rw)        params.rw = rw
+      if (villageId) params.village_id = villageId
     }
 
     commit('SET_STATUS', 'LOADING')


### PR DESCRIPTION
## FEAT

- **Dynamic params non-warga**: Semua role selain warga kini mengirim semua params tersedia (`rt`, `rw`, `village_id`) saat fetch history, bukan hanya satu param spesifik per role
- **Masking konsisten di PreviewModal**: Field sensitif (nama, NIK, KK) kini selalu diambil dari list item, bukan detail API response, agar konsisten dengan tampilan di list
- **Sembunyikan foto untuk non-self item**: Foto rumah tidak ditampilkan untuk item milik orang lain karena termasuk data sensitif

## Related

-

## Overview
Dua bug fix pada fitur History Imah Aing yang berdampak pada akurasi data fetch dan keamanan tampilan data sensitif.

1. **fetchHistory non-warga**: Switch-case yang rigid diganti `if/else` dinamis. Sebelumnya tiap role hanya bisa mengirim satu param filter; kini semua param yang tersedia dikirim sekaligus, sehingga RT/RW/Kades/Lurah mendapat hasil fetch yang lebih akurat.

2. **PreviewModal masking**: Computed `displayName`, `displayNik`, `displayKk` sebelumnya menggunakan `resolvedItem` (prioritas: detail API → list item). Karena response detail endpoint memiliki struktur field berbeda, masking bisa tidak konsisten. Fix: field sensitif selalu dari `this.item` (list item).

3. **Foto tersembunyi**: `photos` computed kini return `[]` jika `!isSelfItem`, sehingga foto tidak pernah tampil untuk item orang lain.

## Changes

- **`store/imah-aing/imahAingHistory.js`**:
  - Ganti `switch (roleLower)` dengan `if/else` — warga tetap pakai `user_kk`, non-warga tambahkan semua dari `rt`, `rw`, `village_id` yang non-empty

- **`components/ImahAing/History/PreviewModal.vue`**:
  - `displayName`, `displayNik`, `displayKk` → source dari `this.item` bukan `this.resolvedItem`
  - `photos` → return `[]` jika `!isSelfItem`
  - Tambah prop `isSelfItem`, computed masking, method `maskName` dan `maskNumber`

- **`components/ImahAing/History/ListItem.vue`**:
  - Tambah `displayName` computed dengan masking, prop `isSelfItem`, `proposerRole`, `proposerName`
  - Tampilkan label pengusul (`proposerLabel`)

- **`pages/imah-aing/index.vue`**:
  - Tambah method `isSelfItem()`, `canEdit()`, `editUsulan()`, `showEditInfo()`
  - Pass prop `is-self-item`, `proposer-role`, `proposer-name` ke ListItem dan PreviewModal

- **`store/imah-aing/imahAingForm.js`** & **`components/ImahAing/Form/StepFour.vue`**:
  - Pre-fill dan disable field lokasi untuk non-warga

## Preview

-

## Evidence
title: fix(imah-aing): history non-warga dynamic params & preview masking fix
project: Sapawarga
participants: @ekadhirapratama
screenshot: https://s.digitalservice.id/YTMiiK