### PR TITLE
fix(imah-aing): replace legacy aduan status with complete Imah Aing status mapping

### DIFF
--- a/components/ImahAing/History/ListItem.vue
+++ b/components/ImahAing/History/ListItem.vue
@@ -6,15 +6,15 @@
     <!-- Checkbox — large tap target (44px) for mobile, stop propagation agar tidak trigger klik item -->
     <label
       class="relative flex items-center justify-center w-11 h-11 -ml-2 -mt-2 flex-shrink-0"
-      :class="isVerified ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'"
+      :class="isNonEditable ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'"
       @click.stop
     >
       <input
         type="checkbox"
         :checked="selected"
-        :disabled="isVerified"
+        :disabled="isNonEditable"
         class="w-5 h-5 rounded border-gray-300 text-[#069550] focus:ring-[#069550] focus:ring-2"
-        :class="isVerified ? 'cursor-not-allowed' : 'cursor-pointer'"
+        :class="isNonEditable ? 'cursor-not-allowed' : 'cursor-pointer'"
         @change="$emit('toggle')"
       />
     </label>
@@ -106,7 +106,7 @@ export default {
     }
   },
   computed: {
-    /** Kunci status — satu sumber untuk isVerified dan statusStyle */
+    /** Kunci status — satu sumber untuk isNonEditable dan statusStyle */
     statusKey() {
       return this.item.complaint_status?.id
         || this.item.complaint_status_id
@@ -114,8 +114,8 @@ export default {
         || this.item.status
         || ''
     },
-    isVerified() {
-      return this.statusKey === 'verified'
+    isNonEditable() {
+      return !['unverified', 'rejected_appeal'].includes(this.statusKey)
     },
     /** Objek style guide (name + hex) dari mapping 13 status */
     statusStyle() {

--- a/components/ImahAing/History/PreviewModal.vue
+++ b/components/ImahAing/History/PreviewModal.vue
@@ -117,7 +117,7 @@
 
 <script>
 import { formatDate } from '~/utils'
-import { newDataStatusMilestone } from '~/constant/status-milestone'
+import { getImahAingStatus } from '~/constant/imah-aing-status'
 
 export default {
   name: 'ImahAingHistoryPreviewModal',
@@ -166,23 +166,15 @@ export default {
       return Array.isArray(photos) ? photos : []
     },
     statusLabel() {
-      // detail response: complaint_status.name (ready-to-display) or complaint_status_id (key)
-      // list response: phase or status (key)
       if (this.resolvedItem?.complaint_status?.name) {
         return this.resolvedItem.complaint_status.name
       }
-      const phase =
+      const key =
         this.resolvedItem?.complaint_status_id ||
         this.resolvedItem?.phase ||
         this.resolvedItem?.status ||
         ''
-      const mapping = {
-        unverified: 'Menunggu Verifikasi',
-        verified: 'Terverifikasi',
-        failed: 'Gagal Diverifikasi',
-        directed_to_hotline_jabar: 'Dialihkan ke Hotline Jabar',
-      }
-      return newDataStatusMilestone[phase]?.name || mapping[phase] || phase || '-'
+      return getImahAingStatus(key).name
     },
     formattedDate() {
       const date = this.resolvedItem?.created_at || this.resolvedItem?.submitted_at || ''

--- a/constant/imah-aing-status.js
+++ b/constant/imah-aing-status.js
@@ -1,17 +1,33 @@
 export const IMAH_AING_STATUS = {
-  unverified:                { id: 'unverified',                name: 'Menunggu Verifikasi',       color: 'yellow',     hex: '#FF7500' },
-  verified:                  { id: 'verified',                  name: 'Terverifikasi',             color: 'green',      hex: '#166534' },
-  failed:                    { id: 'failed',                    name: 'Gagal Diverifikasi',        color: 'red',        hex: '#DD5E5E' },
-  directed_to_hotline_jabar: { id: 'directed_to_hotline_jabar', name: 'Dialihkan ke Hotline Jabar', color: 'purple',    hex: '#691B9A' },
-  not_yet_instructed:        { id: 'not_yet_instructed',        name: 'Belum Diinstruksikan',      color: 'yellow',     hex: '#FF7500' },
-  not_yet_coordinated:       { id: 'not_yet_coordinated',       name: 'Belum Dikoordinasikan',     color: 'light-blue', hex: '#1E88E5' },
-  coordinated:               { id: 'coordinated',               name: 'Dikoordinasikan',           color: 'green',      hex: '#166534' },
-  diverted_to_span:          { id: 'diverted_to_span',          name: 'Dialihkan ke SP4N Lapor',   color: 'green',      hex: '#166534' },
-  rejected:                  { id: 'rejected',                  name: 'Ditolak',                   color: 'red',        hex: '#DD5E5E' },
-  followup:                  { id: 'followup',                  name: 'Ditindaklanjuti',           color: 'light-blue', hex: '#1E88E5' },
-  postponed:                 { id: 'postponed',                 name: 'Pengerjaan Ditunda',        color: 'purple',     hex: '#691B9A' },
-  review:                    { id: 'review',                    name: 'Ditinjau Ulang',            color: 'dark-blue',  hex: '#64748B' },
-  finished:                  { id: 'finished',                  name: 'Selesai',                   color: 'green',      hex: '#166534' }
+  // verification
+  unverified:                { id: 'unverified',                phase: 'verification',  name: 'Menunggu Verifikasi',             color: 'yellow',  hex: '#FF7500' },
+  verified:                  { id: 'verified',                  phase: 'verification',  name: 'Terverifikasi',                   color: 'green',   hex: '#166534' },
+  canceled:                  { id: 'canceled',                  phase: 'verification',  name: 'Dibatalkan',                      color: 'red',     hex: '#DD5E5E' },
+  rejected_appeal:           { id: 'rejected_appeal',           phase: 'verification',  name: 'Ditolak (Sanggah)',               color: 'red',     hex: '#DD5E5E' },
+  rejected_criteria:         { id: 'rejected_criteria',         phase: 'verification',  name: 'Ditolak',                         color: 'red',     hex: '#DD5E5E' },
+  directed_to_hotline_jabar: { id: 'directed_to_hotline_jabar', phase: 'verification',  name: 'Dialihkan ke Hotline Jabar',      color: 'purple',  hex: '#691B9A' },
+
+  // authorization (nominatif)
+  central_nominative:        { id: 'central_nominative',        phase: 'authorization', name: 'Nominatif Pusat',                 color: 'yellow',  hex: '#FF7500' },
+  provincial_nominative:     { id: 'provincial_nominative',     phase: 'authorization', name: 'Nominatif Provinsi',              color: 'yellow',  hex: '#FF7500' },
+  regency_nominative:        { id: 'regency_nominative',        phase: 'authorization', name: 'Nominatif Kabupaten/Kota',        color: 'yellow',  hex: '#FF7500' },
+  other_nominative:          { id: 'other_nominative',          phase: 'authorization', name: 'Nominatif Lainnya (CSR)',         color: 'yellow',  hex: '#FF7500' },
+
+  // coordination (pengajuan bantuan)
+  regency_aid_submission:    { id: 'regency_aid_submission',    phase: 'coordination',  name: 'Pengajuan Bantuan Kabupaten/Kota', color: 'light-blue', hex: '#1E88E5' },
+  provincial_aid_submission: { id: 'provincial_aid_submission', phase: 'coordination',  name: 'Pengajuan Bantuan Provinsi',      color: 'light-blue', hex: '#1E88E5' },
+  central_aid_submission:    { id: 'central_aid_submission',    phase: 'coordination',  name: 'Pengajuan Bantuan Pusat',         color: 'light-blue', hex: '#1E88E5' },
+  other_aid_submission:      { id: 'other_aid_submission',      phase: 'coordination',  name: 'Pengajuan Bantuan Lainnya',       color: 'light-blue', hex: '#1E88E5' },
+
+  // coordination (penetapan bantuan)
+  regency_aid_determination:    { id: 'regency_aid_determination',    phase: 'coordination', name: 'Penetapan Bantuan Kabupaten/Kota', color: 'purple', hex: '#691B9A' },
+  provincial_aid_determination: { id: 'provincial_aid_determination', phase: 'coordination', name: 'Penetapan Bantuan Provinsi',        color: 'purple', hex: '#691B9A' },
+  central_aid_determination:    { id: 'central_aid_determination',    phase: 'coordination', name: 'Penetapan Bantuan Pusat',           color: 'purple', hex: '#691B9A' },
+  other_aid_determination:      { id: 'other_aid_determination',      phase: 'coordination', name: 'Penetapan Bantuan Lainnya',         color: 'purple', hex: '#691B9A' },
+
+  // coordination (akhir)
+  rutilahu_repair_process: { id: 'rutilahu_repair_process', phase: 'coordination', name: 'Proses Perbaikan Rutilahu', color: 'light-blue', hex: '#1E88E5' },
+  aid_received:            { id: 'aid_received',            phase: 'coordination', name: 'Telah Menerima Bantuan',    color: 'green',      hex: '#166534' },
 }
 
 /** Fallback aman untuk status yang tidak dikenal */


### PR DESCRIPTION
## FEAT

- **Status mapping Imah Aing**: Ganti 13 status warisan aduan-masuk dengan 20 status Imah Aing yang benar, mencakup fase verification, authorization (nominatif), dan coordination
- **PreviewModal cleanup**: Hapus inline hardcoded mapping + dependensi `newDataStatusMilestone`, pakai `getImahAingStatus()` sebagai single source of truth
- **ListItem refactor**: Rename `isVerified` → `isNonEditable` agar logika disable checkbox mencakup semua status non-editable

## Related

-

## Overview

Status Imah Aing sebelumnya memakai 13 status warisan dari modul aduan-masuk (failed, not_yet_instructed, coordinated, dll.) yang tidak relevan untuk Imah Aing. Perubahan ini menyinkronkan konstanta dengan status aktual dari BE, mengacu pada CMS (`constant/imah-aing.js`) dan Mastersheet Imah Aing.

1. **`constant/imah-aing-status.js`**: 13 status lama → 20 status Imah Aing dengan field `phase` (verification / authorization / coordination)
2. **`PreviewModal.vue`**: Hapus duplikasi mapping inline dan import `newDataStatusMilestone`; gunakan `getImahAingStatus()` konsisten
3. **`ListItem.vue`**: `isVerified` diganti `isNonEditable` yang cek `['unverified', 'rejected_appeal']` — editable statuses yang benar sesuai spec

## Changes

- **`constant/imah-aing-status.js`**:
  - Hapus: `failed`, `not_yet_instructed`, `not_yet_coordinated`, `coordinated`, `diverted_to_span`, `rejected`, `followup`, `postponed`, `review`, `finished`
  - Tambah: `canceled`, `rejected_appeal`, `rejected_criteria`, `central/provincial/regency/other_nominative`, `regency/provincial/central/other_aid_submission`, `regency/provincial/central/other_aid_determination`, `rutilahu_repair_process`, `aid_received`
  - Tiap entry kini punya field `phase`

- **`components/ImahAing/History/PreviewModal.vue` (`components/ImahAing/History/PreviewModal.vue`)**:
  - Ganti import `newDataStatusMilestone` → `getImahAingStatus`
  - Sederhanakan `statusLabel` computed: hapus hardcoded 4-status mapping + fallback chain

- **`components/ImahAing/History/ListItem.vue` (`components/ImahAing/History/ListItem.vue`)**:
  - Rename `isVerified` → `isNonEditable`, update kondisi dan semua pemakaian di template

## Preview

-

## Evidence
title: fix(imah-aing): replace legacy aduan status with complete Imah Aing status mapping
project: Sapawarga
participants: @ekadhirapratama
screenshot: https://s.digitalservice.id/XmoZUt