### PR TITLE
fix(imah-aing): use meta user token for edit submit endpoint

### DIFF
--- a/components/ImahAing/Form/StepOne.vue
+++ b/components/ImahAing/Form/StepOne.vue
@@ -20,7 +20,7 @@
       <ol class="list-decimal ml-5 space-y-1">
         <li>Kartu Tanda Penduduk Calon Penerima Bantuan (Kepala Keluarga) / Surat Keterangan dari Kepala Dusun, Kepala Desa, atau Lurah;</li>
         <li>Kartu Keluarga Calon Penerima Bantuan / Surat Keterangan dari Kepala Dusun, Kepala Desa, atau Lurah;</li>
-        <li>Surat Keterangan Miskin / Tidak Mampu dari Kepala Dusun, Kepala Desa, atau Lurah;</li>
+        <li>Surat Keterangan Miskin / Tidak Mampu dari Ketua RT/RW;</li>
         <li>Surat Keterangan Kepemilikan Tanah dari Kepala Dusun, Kepala Desa, atau Lurah;</li>
         <li>Foto Rumah Tidak Layak (Tampak depan, kiri, kanan, belakang, dalam)</li>
       </ol>

--- a/components/ImahAing/Form/StepThree.vue
+++ b/components/ImahAing/Form/StepThree.vue
@@ -185,7 +185,7 @@ export default {
         },
         {
           key: 'suratMiskin',
-          label: 'Surat Keterangan Miskin / Tidak Mampu dari Kepala Dusun / Kepala Desa / Lurah',
+          label: 'Surat Keterangan Miskin / Tidak Mampu dari Ketua RT/RW',
           required: true,
         },
         {

--- a/store/imah-aing/imahAingForm.js
+++ b/store/imah-aing/imahAingForm.js
@@ -87,6 +87,9 @@ const getDefaultState = () => ({
 
   /** ID usulan yang sedang diedit (mode edit via query param `edit`) */
   editComplaintId: '',
+
+  /** Token user Sapawarga dari query `meta` — dipakai khusus submit mode edit (PUT /mobile) */
+  metaToken: '',
 })
 
 const USER_INCOME_PER_MONTH_KEY = 'user_income_per_month'
@@ -351,6 +354,9 @@ export default {
     SET_EDIT_COMPLAINT_ID(state, id) {
       state.editComplaintId = id || ''
     },
+    SET_META_TOKEN(state, token) {
+      state.metaToken = token || ''
+    },
     RESET_STATE(state) {
       const def = getDefaultState()
       Object.keys(def).forEach((k) => {
@@ -372,6 +378,9 @@ export default {
           applyQueryMetaToDataPengusul(commit, decoded)
           applyQueryMetaToProposerMeta(commit, decoded)
           applyQueryMetaToLokasiTanah(commit, decoded)
+          if (decoded.token) {
+            commit('SET_META_TOKEN', String(decoded.token).trim())
+          }
         }
       }
     },
@@ -773,7 +782,7 @@ export default {
         throw error
       }
     },
-    async submitForm({ commit, state }) {
+    async submitForm({ commit, state, rootState }) {
       commit('SET_STATUS_SUBMIT', 'LOADING')
       try {
         const docMapping = [
@@ -837,12 +846,14 @@ export default {
           RW: String(rw || ''),
         }
 
-        // Mode edit (US-013): PUT update ke endpoint /mobile
-        // Mode buat baru: POST create
+        // Mode edit (US-013): PUT update ke endpoint /mobile — pakai token user Sapawarga dari
+        // query `meta`, BUKAN token Keycloak client_credentials (kebutuhan integrasi backend).
+        // Mode buat baru: POST create tetap pakai authToken Keycloak.
         const isEdit = !!state.editComplaintId
-        const headers = state.authToken
-          ? { Authorization: `Bearer ${state.authToken}` }
-          : {}
+        const metaToken = state.metaToken || rootState.imahAingHistory?.metaPayload?.token || ''
+        const headers = isEdit
+          ? (metaToken ? { Authorization: `Bearer ${metaToken}` } : {})
+          : (state.authToken ? { Authorization: `Bearer ${state.authToken}` } : {})
 
         const sendComplaint = () =>
           isEdit


### PR DESCRIPTION
## FEAT

- **Meta user token untuk edit submit**: endpoint `PUT /aduan/complaints/:id/mobile` (update pengajuan mode edit) sekarang pakai token user Sapawarga dari query `meta`, bukan token Keycloak `client_credentials`.
- **Redaksi penerbit Surat Keterangan Miskin/Tidak Mampu**: ganti dari Kepala Dusun/Kepala Desa/Lurah menjadi Ketua RT/RW sesuai feedback lapangan.

## Related

-

## Overview
Menyesuaikan header otentikasi khusus endpoint update pengajuan Imah Aing sesuai kebutuhan integrasi backend, serta memperbaiki redaksi persyaratan dokumen Surat Keterangan Miskin/Tidak Mampu.

1. **Simpan `metaToken` saat init form**: `initForm` decode query `meta`, kalau ada `token` disimpan ke `state.metaToken`.
2. **Pakai `metaToken` khusus mode edit**: `submitForm` pakai `state.metaToken` (fallback `imahAingHistory.metaPayload.token`) untuk request PUT `/mobile`; mode buat baru (POST create) tetap pakai `authToken` Keycloak seperti sebelumnya.
3. **Ganti penerbit Surat Keterangan Miskin/Tidak Mampu jadi RT/RW**: label syarat dokumen di Step 1 (list) dan Step 3 (upload) diubah dari "dari Kepala Dusun, Kepala Desa, atau Lurah" menjadi "dari Ketua RT/RW".

## Changes

- **Store Imah Aing Form (`store/imah-aing/imahAingForm.js`)**:
  - Tambah state `metaToken` di `getDefaultState()`
  - Tambah mutation `SET_META_TOKEN`
  - `initForm`: commit `metaToken` dari `decoded.token` kalau ada
  - `submitForm`: header `Authorization` PUT `/mobile` (mode edit) pakai `metaToken`, POST create (mode baru) tetap pakai `authToken` Keycloak
- **Step One (`components/ImahAing/Form/StepOne.vue`)**:
  - Ubah redaksi item syarat dokumen Surat Keterangan Miskin/Tidak Mampu, penerbit dari Kepala Dusun/Kepala Desa/Lurah jadi Ketua RT/RW
- **Step Three (`components/ImahAing/Form/StepThree.vue`)**:
  - Ubah label upload dokumen Surat Keterangan Miskin/Tidak Mampu, penerbit dari Kepala Dusun/Kepala Desa/Lurah jadi Ketua RT/RW

## Preview

-

## Evidence
title: fix(imah-aing): use meta user token for edit submit endpoint
project: Sapawarga
participants: @ekadhirapratama
screenshot: https://s.digitalservice.id/lBV2NR