### PR TITLE
fix(imah-aing): reuse return-to-list handler for session expired

### DIFF
--- a/pages/imah-aing/form/index.vue
+++ b/pages/imah-aing/form/index.vue
@@ -132,7 +132,7 @@
       name-icon="check-mark-circle"
       size="16px"
       :description="successDescription"
-      @close="handleCloseAfterSuccess"
+      @close="handleReturnToList"
       @click="backToFormPage"
     />
 
@@ -157,7 +157,7 @@
       size="16px"
       description="Maaf, sesi Anda telah habis. Untuk melanjutkan, silakan masuk kembali dan kirim ulang pengajuan Anda."
       @close="handleSessionExpired"
-      @click="handleSessionExpired"
+      @click="handleReturnToList"
     />
   </div>
 </template>
@@ -368,7 +368,7 @@ export default {
         this.isLoading = false
       }, 1500)
     },
-    handleCloseAfterSuccess() {
+    handleReturnToList() {
       const { id, nomorKk } = this.$store.state.imahAingForm.dataPengusul || {}
       if (id || nomorKk) {
         this.$router.push({


### PR DESCRIPTION
## FEAT

- **Popup SESSION_EXPIRED - action "Masuk Kembali"**: sekarang reuse logic redirect yang sama dengan popup SUCCESS (`handleReturnToList`), bukan full page reload lagi.

## Related

-

## Overview

Popup konfirmasi sesi habis (SESSION_EXPIRED) di form Imah Aing sebelumnya cuma `window.location.reload()` buat kedua action button-nya. Sesuai feedback, tombol "Masuk Kembali" diubah supaya konsisten sama pola popup SUCCESS: redirect ke daftar riwayat pengajuan (`/imah-aing`) kalau data pengusul sudah ada, atau reset balik ke step 1 form kalau belum.

1. **Reuse handler `handleReturnToList`**: method `handleCloseAfterSuccess` di-rename generic jadi `handleReturnToList`, dipakai bareng oleh popup SUCCESS (`@close`) dan popup SESSION_EXPIRED (`@click` tombol "Masuk Kembali").
2. **Popup SESSION_EXPIRED `@close` (tombol "Tutup"/header X) belum diubah**: masih pakai `handleSessionExpired` (reload) — integrasi deep link balik ke app native jadi task terpisah menyusul.

## Changes

- **`pages/imah-aing/form/index.vue`**:
  - Rename method `handleCloseAfterSuccess` → `handleReturnToList` (logic sama: redirect ke `/imah-aing` kalau `dataPengusul.id`/`nomorKk` ada, else `backToFormPage()`)
  - Popup SUCCESS: `@close="handleReturnToList"` (sebelumnya `handleCloseAfterSuccess`)
  - Popup SESSION_EXPIRED: `@click="handleReturnToList"` buat tombol "Masuk Kembali" (sebelumnya `handleSessionExpired`)

## Preview

-

## Evidence
title: fix(imah-aing): reuse return-to-list handler for session expired confirm
project: Sapawarga
participants: @ekadhirapratama
screenshot: https://s.digitalservice.id/OVyGt4