### PR TITLE
fix(imah-aing): require detail alamat and titik lokasi in step four

### DIFF
--- a/components/ImahAing/Form/StepFour.vue
+++ b/components/ImahAing/Form/StepFour.vue
@@ -145,7 +145,9 @@
         </section>
 
         <ValidationProvider
+          ref="locationProvider"
           v-slot="{ errors }"
+          rules="required"
           class="flex flex-col gap-2"
           name="Titik Lokasi Tanah"
         >
@@ -153,10 +155,7 @@
             for="location"
             class="text-sm font-medium text-black font-roboto dark:text-dark-emphasis-high"
           >
-            Titik Lokasi Tanah
-            <span class="text-gray-300 dark:text-dark-emphasis-high">
-              (opsional)
-            </span>
+            Titik Lokasi Tanah <span class="text-red-500">*</span>
           </label>
           <JdsInputText
             id="location"
@@ -182,6 +181,8 @@
         </ValidationProvider>
 
         <ValidationProvider
+          v-slot="{ errors }"
+          rules="required"
           class="flex flex-col gap-2"
           name="Detail Lokasi Tambahan"
         >
@@ -189,10 +190,7 @@
             for="additionalLocation"
             class="text-sm font-medium text-black font-roboto dark:text-dark-emphasis-high"
           >
-            Detail lokasi tambahan
-            <span class="text-gray-300 dark:text-dark-emphasis-high">
-              (opsional)
-            </span>
+            Detail Alamat <span class="text-red-500">*</span>
           </label>
           <textarea
             id="additionalLocation"
@@ -205,6 +203,9 @@
           />
           <p class="text-xs text-left text-gray-600">
             Tersisa {{ 1000 - setValueAddressDetail.length }} karakter
+          </p>
+          <p v-if="errors[0]" class="text-xs text-left text-red-500">
+            {{ errors[0] }}
           </p>
         </ValidationProvider>
       </section>
@@ -410,6 +411,9 @@ export default {
         value: { ...this.cloneLocation.place },
       })
       this.closeMaps()
+      this.$nextTick(() => {
+        this.$refs.locationProvider?.validate()
+      })
     },
     setDusun(value) {
       this.$store.commit('imahAingForm/SET_LOKASI_TANAH_FIELD', {


### PR DESCRIPTION
## FEAT

- **Detail Alamat mandatory**: label diganti dari "Detail lokasi tambahan" jadi "Detail Alamat", ditambah validasi wajib diisi.
- **Titik Lokasi Tanah mandatory**: field wajib dipilih via modal peta sebelum submit.

## Related

- Carry over dari `.spec/plans/plan-2026-07-21.md` (task baru, source: direct request)

## Overview
Form Section 4 Imah Aing (`StepFour.vue`) sebelumnya punya 2 field opsional (Detail Lokasi Tambahan & Titik Lokasi Tanah) yang sekarang dijadikan wajib diisi.

1. **Detail Alamat**: label diubah, ditambah `rules="required"` pada `ValidationProvider`, pesan error ditampilkan di bawah textarea.
2. **Titik Lokasi Tanah**: ditambah `rules="required"`. Karena field readonly diisi lewat modal peta (bukan native input event), `handleLocation()` sekarang manual trigger `validate()` lewat `ref="locationProvider"` supaya state error ter-refresh begitu user pilih lokasi.

## Changes

- **StepFour.vue (`components/ImahAing/Form/StepFour.vue`)**:
  - Rename label "Detail lokasi tambahan" → "Detail Alamat", hapus badge "(opsional)", tambah tanda wajib `*`
  - Tambah `rules="required"` + tampilan pesan error untuk field Detail Alamat
  - Hapus badge "(opsional)" pada label Titik Lokasi Tanah, tambah tanda wajib `*`
  - Tambah `rules="required"` + `ref="locationProvider"` pada `ValidationProvider` Titik Lokasi Tanah
  - `handleLocation()`: tambah manual `validate()` trigger via `$nextTick` setelah commit lokasi ke store

## Preview

-

## Evidence
title: fix(imah-aing): require detail alamat and titik lokasi in step four
project: Sapawarga
participants: @ekadhirapratama
screenshot: https://s.digitalservice.id/E1xj2h